### PR TITLE
Fix for JENKINS-22325

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -461,7 +461,6 @@ public class RemoteBuildConfiguration extends Builder {
             return true;
         }
         String remoteServerURL = remoteServer.getAddress().toString();
-        
         List<String> cleanedParams = null;
 
         if (this.loadParamsFromFile) {
@@ -511,7 +510,7 @@ public class RemoteBuildConfiguration extends Builder {
                 }
                 listener.getLogger().println("Remote job remote job " + jobName + " is not currenlty building.");    
             } else {
-                this.failBuild(new Exception("Got a blank response from Remote Jenkins Server [" + remoteServerURL + "], cannot continue."), listener);
+                this.failBuild(new Exception("Got a blank response from Remote Jenkins Server, cannot continue."), listener);
             }
 
         } else {
@@ -524,6 +523,7 @@ public class RemoteBuildConfiguration extends Builder {
         //listener.getLogger().println("Getting ID of next job to build. URL: " + queryUrlString);
         JSONObject queryResponseObject = sendHTTPCall(queryUrlString, "GET", build, listener);
         if (queryResponseObject == null ) {
+            //This should not happen as this page should return a JSON object
             this.failBuild(new Exception("Got a blank response from Remote Jenkins Server [" + remoteServerURL + "], cannot continue."), listener);
         }
         
@@ -538,9 +538,8 @@ public class RemoteBuildConfiguration extends Builder {
 
         listener.getLogger().println("Triggering remote job now.");
         sendHTTPCall(triggerUrlString, "POST", build, listener);
-
         
-        //        String jobURL = responseObject.getString("url");
+        //Have to form the string ourselves, as we might not get a response from non-parameterized builds
         String jobURL = remoteServerURL + "/job/" + this.encodeValue(job) + "/";
 
         // This is only for Debug


### PR DESCRIPTION
I felt responsible for this issue as I caused it by implementing the JSON response from sendHTTPCall so I thought I should submit a fix.

Please feel free to use or ignore this as you wish.

As per comment in Issue:
Looks like the URL used when no parameters are provided (normalBuildUrl=build) doesn't return any JSON. When the paramerizedBuildUrl URL is used (buildWithParameters) Jenkins returns a JSON string that is converted into an object.

I looked into just using 'buildWithParameters' for both, but I get a 500 error when calling non-parameterised jobs with 'buildWithParameters'.

I see two options:
You can update sendHTTPCall to return null when no JSON is returned from the remote Server. The main issue with this method is all calls to sendHTTPCall will have to check response for null values.
Either that or pass the bug to JenkinsCore to ask them to return JSON objects from 'build' link.

Note: I have implemented the first option (as the second would rely on a specific version of Jenkins or above).
