### PR TITLE
Added URL encode to HTTP GET to check if target remote job is parameterized

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -913,7 +913,7 @@ public class RemoteBuildConfiguration extends Builder {
         remoteServerUrl += "/api/json";
         
         try {
-            JSONObject response = sendHTTPCall(remoteServerUrl, "GET", build, listener);
+            JSONObject response = sendHTTPCall(encodeValue(remoteServerUrl), "GET", build, listener);
 
             if(response.getJSONArray("actions").size() >= 1){
                 isParameterized = true;


### PR DESCRIPTION
Previously, a remote job with spaces in the name would
cause a failure while attempting to check for job parameters. This
caused each build trigger step to retry the parameterization check 5
times and then swallow the resulting AbortException.
