### PR TITLE
Allow trigger of unparameterized jobs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -1172,6 +1172,7 @@ public class RemoteBuildConfiguration extends Builder {
                     JSONObject action = actions.getJSONObject(i);
                     if(action.size() > 0) {
                         isParameterized = true;
+                        break;
                     }
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -1164,8 +1164,16 @@ public class RemoteBuildConfiguration extends Builder {
         try {
             JSONObject response = sendHTTPCall(remoteServerUrl, "GET", build, listener);
 
-            if(response.getJSONArray("actions").size() >= 1){
-                isParameterized = true;
+            JSONArray actions = response.getJSONArray("actions");
+            if(actions.size() >= 1) {
+                // Jenkins often returns a lot of empty action objects. Make sure
+                // that at least one action object has some key-value-pairs in it.
+                for(int i = 0; i < actions.size(); i++) {
+                    JSONObject action = actions.getJSONObject(i);
+                    if(action.size() > 0) {
+                        isParameterized = true;
+                    }
+                }
             }
             
         } catch (IOException e) {


### PR DESCRIPTION
This method does not work on any jenkins I've tested it, because the actions array in the returning JSON always has some empty objects, e.g.:

```
"actions": [
    {},
    {}
  ],
```

This also happens for jobs that does not have any parameters. In this case the plugin determined, that the actions are not empty and the remote job is parameterized (which it actually isn't).

The plugin then triggers the job via the `buildWithParameters` URL, which doesn't work for unparameterized jobs.

This fix will check if at least one of the objects in the actions array contains any content. If not we assume the job is not parameterized.

_Update:_ Before the current plugin version (2.2.0), which is actually not in the central repository for some reason, this bug might have not be noticed, since inside this method the jobname was not escaped. That way any call to a job containing spaces or so, leaded to this method not doing anything and the isRemoteJobParameterized flag keeping on false. Only due to the fix with the escaping this shows more often (at least if you use any characters which needs url encoding).
