### PR TITLE
[JENKINS-24240] Support Remote jobs in Folders

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -383,11 +383,11 @@ public class RemoteBuildConfiguration extends Builder {
             triggerUrlString += buildTokenRootUrl;
             triggerUrlString += getBuildTypeUrl(isRemoteJobParameterized);
 
-            this.addToQueryString("job=" + this.encodeValue(job));
+            this.addToQueryString("job=" + this.encodeValue(job)); // works w/o generateJobPath()ing
 
         } else {
             triggerUrlString += "/job/";
-            triggerUrlString += this.encodeValue(job);
+            triggerUrlString += this.generateJobPath(job);
             triggerUrlString += getBuildTypeUrl(isRemoteJobParameterized);
         }
 
@@ -428,7 +428,7 @@ public class RemoteBuildConfiguration extends Builder {
         String urlString = remoteServer.getAddress().toString();
 
         urlString += "/job/";
-        urlString += this.encodeValue(job);
+        urlString += this.generateJobPath(job);
 
         // don't try to include a security token in the URL if none is provided
         if (!securityToken.equals("")) {
@@ -588,7 +588,7 @@ public class RemoteBuildConfiguration extends Builder {
         BuildInfoExporterAction.addBuildInfoExporterAction(build, jobName, nextBuildNumber, Result.NOT_BUILT);
         
         //Have to form the string ourselves, as we might not get a response from non-parameterized builds
-        String jobURL = remoteServerURL + "/job/" + this.encodeValue(jobName) + "/";
+        String jobURL = remoteServerURL + "/job/" + this.generateJobPath(jobName) + "/";
 
         // This is only for Debug
         // This output whether there is another job running on the remote host that this job had conflicted with.
@@ -1063,6 +1063,18 @@ public class RemoteBuildConfiguration extends Builder {
         return cleanValue;
     }
 
+    /**
+     * Helper function for generating a job path
+     */
+    private String generateJobPath(String jobName) {
+        String[] parts = jobName.split("/");
+        String[] encodedParts = new String[parts.length];
+        for (int i = 0; i < parts.length; i++) {
+            encodedParts[i] = this.encodeValue(parts[i]);
+        }
+        return StringUtils.join(encodedParts, "/job/");
+    }
+
     // Getters
     public String getRemoteJenkinsName() {
         return this.remoteJenkinsName;
@@ -1158,7 +1170,7 @@ public class RemoteBuildConfiguration extends Builder {
         //build the proper URL to inspect the remote job
         RemoteJenkinsServer remoteServer = this.findRemoteHost(this.getRemoteJenkinsName());
         String remoteServerUrl = remoteServer.getAddress().toString();
-        remoteServerUrl += "/job/" + encodeValue(jobName);
+        remoteServerUrl += "/job/" + generateJobPath(jobName);
         remoteServerUrl += "/api/json";
         
         try {

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfigurationTest.java
@@ -5,6 +5,7 @@ import net.sf.json.JSONObject;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockFolder;
 
 public class RemoteBuildConfigurationTest {
     @Rule
@@ -29,6 +30,35 @@ public class RemoteBuildConfigurationTest {
         FreeStyleProject remoteProject = jenkinsRule.createFreeStyleProject();
 
         FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+        RemoteBuildConfiguration remoteBuildConfiguration = new RemoteBuildConfiguration(
+                remoteJenkinsServer.getDisplayName(), false, remoteProject.getFullName(), "",
+                "", true, null, null, false, true, 1);
+        project.getBuildersList().add(remoteBuildConfiguration);
+
+        jenkinsRule.buildAndAssertSuccess(project);
+    }
+
+    @Test
+    public void testRemoteFolderedBuild() throws Exception {
+        jenkinsRule.jenkins.setCrumbIssuer(null);
+
+        JSONObject authenticationMode = new JSONObject();
+        authenticationMode.put("value", "none");
+        JSONObject auth = new JSONObject();
+        auth.put("authenticationMode", authenticationMode);
+
+        String remoteUrl = jenkinsRule.getURL().toString();
+        RemoteJenkinsServer remoteJenkinsServer =
+                new RemoteJenkinsServer(remoteUrl, "JENKINS", false, auth);
+        RemoteBuildConfiguration.DescriptorImpl descriptor =
+                jenkinsRule.jenkins.getDescriptorByType(RemoteBuildConfiguration.DescriptorImpl.class);
+        descriptor.setRemoteSites(remoteJenkinsServer);
+
+        MockFolder remoteJobFolder = jenkinsRule.createFolder("someJobFolder");
+        FreeStyleProject remoteProject = remoteJobFolder.createProject(FreeStyleProject.class, "someJobName");
+
+        FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+
         RemoteBuildConfiguration remoteBuildConfiguration = new RemoteBuildConfiguration(
                 remoteJenkinsServer.getDisplayName(), false, remoteProject.getFullName(), "",
                 "", true, null, null, false, true, 1);


### PR DESCRIPTION
This change adds a generateJobPath() helper function which turns job
names into encoded job names. Job names are split on '/', each part is
run through encodeValue(), then the resulting encoded parts are joined
by "/job/". All instances where encodeValue(job) was used to build a job
URL have been replaced with calls to generateJobPath().

A new test was added to handle the case where a job is in a folder.
