### PR TITLE
Add buildRemote workflow step

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.580</version>
+    <version>1.609.1</version>
   </parent>
 
   <artifactId>Parameterized-Remote-Trigger</artifactId>
@@ -75,6 +75,11 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>token-macro</artifactId>
       <version>1.9</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <version>1.12</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,13 @@
       <artifactId>workflow-step-api</artifactId>
       <version>1.12</version>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <version>1.12</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BuildInfoExporterAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BuildInfoExporterAction.java
@@ -4,6 +4,7 @@ import hudson.EnvVars;
 import hudson.model.EnvironmentContributingAction;
 import hudson.model.Result;
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -22,14 +23,14 @@ class BuildInfoExporterAction implements EnvironmentContributingAction {
 
     private List<BuildReference> builds;
 
-    public BuildInfoExporterAction(AbstractBuild<?, ?> parentBuild, BuildReference buildRef) {
+    public BuildInfoExporterAction(Run<?, ?> parentBuild, BuildReference buildRef) {
         super();
 
         this.builds = new ArrayList<BuildReference>();
         this.builds.add(buildRef);
     }
 
-    static BuildInfoExporterAction addBuildInfoExporterAction(AbstractBuild<?, ?> parentBuild, String triggeredProject, int buildNumber, Result buildResult) {
+    static BuildInfoExporterAction addBuildInfoExporterAction(Run<?, ?> parentBuild, String triggeredProject, int buildNumber, Result buildResult) {
         BuildReference reference = new BuildReference(triggeredProject, buildNumber, buildResult);
 
         BuildInfoExporterAction action = parentBuild.getAction(BuildInfoExporterAction.class);

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BuildRemoteStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BuildRemoteStep.java
@@ -1,0 +1,205 @@
+package org.jenkinsci.plugins.ParameterizedRemoteTrigger;
+
+import com.google.inject.Inject;
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.util.ListBoxModel;
+import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Jenkins workflow step for triggering a Jenkins job on a remote server.
+ */
+public class BuildRemoteStep extends AbstractStepImpl {
+    private final String remoteJenkinsName;
+    private final String job;
+    private String token = "";
+    private boolean wait = DescriptorImpl.defaultWait;
+    private boolean propagate = DescriptorImpl.defaultPropagate;
+    private Map<String, String> parameters = new LinkedHashMap<String, String>();
+
+    @DataBoundConstructor
+    public BuildRemoteStep(String remoteJenkinsName, String job) {
+        this.remoteJenkinsName = remoteJenkinsName;
+        this.job = job.trim();
+    }
+
+    public String getRemoteJenkinsName() {
+        return remoteJenkinsName;
+    }
+
+    public String getJob() {
+        return job;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    @DataBoundSetter
+    public void setToken(String token) {
+        this.token = Util.fixNull(token);
+    }
+
+    public Map<String, String> getParameters() {
+        return parameters;
+    }
+
+    @DataBoundSetter
+    public void setParameters(Map<String, String> parameters) {
+        this.parameters = parameters;
+    }
+
+    public boolean getWait() {
+        return wait;
+    }
+
+    @DataBoundSetter
+    public void setWait(boolean wait) {
+        this.wait = wait;
+    }
+
+    public boolean getPropagate() {
+        return propagate;
+    }
+
+    @DataBoundSetter
+    public void setPropagate(boolean propagate) {
+        this.propagate = propagate;
+    }
+
+    public static class Execution extends AbstractSynchronousNonBlockingStepExecution<Void> {
+        private static final long serialVersionUID = 1L;
+
+        @Inject
+        private transient BuildRemoteStep step;
+        @StepContextParameter
+        private transient Run run;
+        @StepContextParameter
+        private transient TaskListener listener;
+
+        @Override
+        protected Void run() throws Exception {
+            RemoteBuildConfiguration remoteBuildConfiguration = new RemoteBuildConfiguration(
+                    step.getRemoteJenkinsName(), !step.getPropagate(), step.getJob(), step.getToken(),
+                    parametersToString(step.getParameters()), false, null, null, false, step.getPropagate(), 10);
+            remoteBuildConfiguration.perform(run, null, null, listener);
+            return null;
+        }
+
+        private String parametersToString(Map<String, String> parameters) {
+            StringBuilder parametersBuilder = new StringBuilder();
+            if (parameters != null) {
+                for (Map.Entry<String, String> parameter : parameters.entrySet()) {
+                    parametersBuilder.append(parameter.getKey()).append('=').append(parameter.getValue()).append('\n');
+                }
+            }
+            return parametersBuilder.toString().trim();
+        }
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+        public static boolean defaultWait = true;
+        public static boolean defaultPropagate = true;
+
+        @Inject
+        private transient RemoteBuildConfiguration.DescriptorImpl remoteBuildConfigurationDescriptor;
+
+        public DescriptorImpl() {
+            super(Execution.class);
+            load();
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "buildRemote";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Trigger a remote parameterized job";
+        }
+
+        @Override
+        public Step newInstance(Map<String, Object> arguments) throws Exception {
+            Map<String, String> parameters = null;
+            if (arguments.containsKey("parameters")) {
+                parameters = (Map<String, String>) arguments.get("parameters");
+                arguments.remove("parameters");
+            }
+
+            BuildRemoteStep step = (BuildRemoteStep)super.newInstance(arguments);
+
+            if (parameters != null) {
+                step.setParameters(parameters);
+            }
+
+            return step;
+        }
+
+        @Override
+        public Step newInstance(@CheckForNull StaplerRequest req, @Nonnull JSONObject formData) throws FormException {
+            String parameters = formData.getString("parameters");
+            formData.remove("parameters");
+
+            Map<String, String> parsedParameters;
+            try {
+                parsedParameters = parseParameters(parameters);
+            } catch (IOException e) {
+                throw new FormException(e, "parameters");
+            }
+
+            BuildRemoteStep step = (BuildRemoteStep)super.newInstance(req, formData);
+            step.setParameters(parsedParameters);
+            return step;
+        }
+
+        public ListBoxModel doFillRemoteJenkinsNameItems() {
+            ListBoxModel model = new ListBoxModel();
+
+            for (RemoteJenkinsServer site : remoteBuildConfigurationDescriptor.getRemoteSites()) {
+                model.add(site.getDisplayName());
+            }
+
+            return model;
+        }
+
+        /**
+         * Reads the parameters from the given string as if it where a property file.
+         * @param parameters a string containing a list of properties in property file format
+         * @return a map containing the parameter names and values
+         * @throws IOException when the parameters could not be read
+         */
+        private Map<String, String> parseParameters(String parameters) throws IOException {
+            Properties parameterProperties = new Properties();
+            parameterProperties.load(new StringReader(parameters));
+
+            Map<String, String> parsedParameters = new LinkedHashMap<String, String>();
+            Enumeration parameterNames = parameterProperties.propertyNames();
+            while (parameterNames.hasMoreElements()) {
+                String parameterName = (String)parameterNames.nextElement();
+                parsedParameters.put(parameterName, parameterProperties.getProperty(parameterName));
+            }
+            return parsedParameters;
+        }
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BuildRemoteStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BuildRemoteStep/config.jelly
@@ -1,0 +1,24 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:section title="Server Info">
+        <f:entry title="Select a remote host" >
+            <f:select field="remoteJenkinsName" />
+        </f:entry>
+    </f:section>
+    <f:section title="Job Info">
+        <f:entry title="Remote Job Name" field="job">
+             <f:textbox />
+        </f:entry>
+        <f:entry title="Token" field="token">
+            <f:textbox />
+        </f:entry>
+        <f:entry field="wait">
+            <f:checkbox title="Wait for completion" default="${descriptor.defaultWait}"/>
+        </f:entry>
+        <f:entry field="propagate">
+            <f:checkbox title="Propagate errors" default="${descriptor.defaultPropagate}"/>
+        </f:entry>
+        <f:entry title="Parameters" field="parameters">
+             <f:textarea />
+        </f:entry>
+    </f:section>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BuildRemoteStep/help-job.html
+++ b/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BuildRemoteStep/help-job.html
@@ -1,0 +1,3 @@
+<p>
+	The job on the remote Jenkins host which you would like to trigger.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BuildRemoteStep/help-parameters.html
+++ b/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BuildRemoteStep/help-parameters.html
@@ -1,0 +1,3 @@
+<p>
+	Parameters which will be used when triggering the remote job. If no parameters are needed, then just leave this blank.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BuildRemoteStep/help-propagate.html
+++ b/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BuildRemoteStep/help-propagate.html
@@ -1,0 +1,3 @@
+<p>
+    If this option is disabled, the build will not fail even if the remote build fails.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BuildRemoteStep/help-token.html
+++ b/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BuildRemoteStep/help-token.html
@@ -1,0 +1,3 @@
+<p>
+	Security token which is defined on the job of the remote Jenkins host. If no job token is needed to trigger this job, then just leave it blank.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BuildRemoteStep/help-wait.html
+++ b/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BuildRemoteStep/help-wait.html
@@ -1,0 +1,3 @@
+<p>
+    You may ask that this workflow build wait for completion of the downstream build.
+</p>

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BuildRemoteStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BuildRemoteStepTest.java
@@ -1,0 +1,42 @@
+package org.jenkinsci.plugins.ParameterizedRemoteTrigger;
+
+import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class BuildRemoteStepTest {
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+
+    @Test
+    public void configRoundTrip() throws Exception {
+        JSONObject authenticationMode = new JSONObject();
+        authenticationMode.put("value", "none");
+        JSONObject auth = new JSONObject();
+        auth.put("authenticationMode", authenticationMode);
+
+        String remoteUrl = jenkinsRule.getURL().toString();
+        RemoteJenkinsServer remoteJenkinsServer =
+                new RemoteJenkinsServer(remoteUrl, "JENKINS", false, auth);
+        RemoteBuildConfiguration.DescriptorImpl descriptor =
+                jenkinsRule.jenkins.getDescriptorByType(RemoteBuildConfiguration.DescriptorImpl.class);
+        descriptor.setRemoteSites(remoteJenkinsServer);
+
+        Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put("name", "value");
+
+        BuildRemoteStep before = new BuildRemoteStep("JENKINS", "jobName");
+        before.setToken("TOKEN");
+        before.setPropagate(false);
+        before.setWait(false);
+        before.setParameters(parameters);
+
+        BuildRemoteStep after = new StepConfigTester(jenkinsRule).configRoundTrip(before);
+        jenkinsRule.assertEqualDataBoundBeans(before, after);
+    }
+}


### PR DESCRIPTION
This change adds a `buildRemote` workflow step for triggering a remote Jenkins job. I have chosen the parameter names to match the parameter names of the standard `build` step. The workflow step doesn't support all the options of the build step yet. Some of them like loading parameters from a file are not really necessary in a workflow. Support for other options can easily be added later.
