### PR TITLE
[JENKINS-33269] Possible deadlock during checking remote job

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -967,7 +967,7 @@ public class RemoteBuildConfiguration extends Builder {
             connection.setRequestMethod(requestType);
             // wait up to 5 seconds for the connection to be open
             connection.setConnectTimeout(5000);
-			connection.setReadTimeout(5000);
+            connection.setReadTimeout(5000);
             connection.connect();
             
             InputStream is;

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -967,6 +967,7 @@ public class RemoteBuildConfiguration extends Builder {
             connection.setRequestMethod(requestType);
             // wait up to 5 seconds for the connection to be open
             connection.setConnectTimeout(5000);
+			connection.setReadTimeout(5000);
             connection.connect();
             
             InputStream is;


### PR DESCRIPTION
Setting read timeout in sendHTTPCall() to 5000 to avoid deadlock during response read.
