### PR TITLE
fix some issues about paramterized build judgement and running exception

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -550,6 +550,9 @@ public class RemoteBuildConfiguration extends Builder {
         listener.getLogger().println("Triggering remote job now.");
         sendHTTPCall(triggerUrlString, "POST", build, listener);
         if(isRemoteParameterized) {
+            // The triggered build may start to run after a few seconds delay, so querying the build immediately may returns null
+            // This sometimes cause the following step getting a wrong build number, which is smaller than the actual value.
+            Thread.sleep(this.pollInterval * 1000);
             // Validate the build number via parameters
             foundIt: for (int tries = 3; tries > 0; tries--) {
                 for (int buildNumber : new SearchPattern(nextBuildNumber, 2)) {

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -977,7 +977,7 @@ public class RemoteBuildConfiguration extends Builder {
                 is = connection.getErrorStream();
             }
             
-            BufferedReader rd = new BufferedReader(new InputStreamReader(is));
+            BufferedReader rd = new BufferedReader(new InputStreamReader(is, "utf-8"));
             String line;
             // String response = "";
             StringBuilder response = new StringBuilder();
@@ -986,7 +986,7 @@ public class RemoteBuildConfiguration extends Builder {
                 response.append(line);
             }
             rd.close();
-            
+
             // JSONSerializer serializer = new JSONSerializer();
             // need to parse the data we get back into struct
             //listener.getLogger().println("Called URL: '" + urlString +  "', got response: '" + response.toString() + "'");

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -519,9 +519,10 @@ public class RemoteBuildConfiguration extends Builder {
                         this.failBuild(e, listener);
                     }
                 }
-                listener.getLogger().println("Remote job remote job " + jobName + " is not currenlty building.");    
+                listener.getLogger().println("Remote job " + jobName + " is not currenlty building.");
             } else {
-                this.failBuild(new Exception("Got a blank response from Remote Jenkins Server, cannot continue."), listener);
+                //this.failBuild(new Exception("Got a blank response from Remote Jenkins Server, cannot continue."), listener);
+                listener.getLogger().println("Remote job " + jobName + " probably not run once, try to continue.");
             }
 
         } else {
@@ -548,42 +549,45 @@ public class RemoteBuildConfiguration extends Builder {
 
         listener.getLogger().println("Triggering remote job now.");
         sendHTTPCall(triggerUrlString, "POST", build, listener);
-        // Validate the build number via parameters
-        foundIt: for (int tries = 3; tries > 0; tries--) {
-            for (int buildNumber : new SearchPattern(nextBuildNumber, 2)) {
-                listener.getLogger().println("Checking parameters of #" + buildNumber);
-                String validateUrlString = this.buildGetUrl(jobName, securityToken) + "/" + buildNumber + "/api/json/";
-                JSONObject validateResponse = sendHTTPCall(validateUrlString, "GET", build, listener);
-                if (validateResponse == null) {
-                    listener.getLogger().println("Query failed.");
-                    continue;
-                }
-                JSONArray actions = validateResponse.getJSONArray("actions");
-                for (int i = 0; i < actions.size(); i++) {
-                    JSONObject action = actions.getJSONObject(i);
-                    if (!action.has("parameters")) continue;
-                    JSONArray parameters = action.getJSONArray("parameters");
-                    // Check if the parameters match
-                    if (compareParameters(listener, parameters, cleanedParams)) {
-                        // We now have a very high degree of confidence that this is the correct build.
-                        // It is still possible that this is a false positive if there are no parameters,
-                        // or multiple jobs use the same parameters.
-                        nextBuildNumber = buildNumber;
-                        break foundIt;
+        if(isRemoteParameterized) {
+            // Validate the build number via parameters
+            foundIt: for (int tries = 3; tries > 0; tries--) {
+                for (int buildNumber : new SearchPattern(nextBuildNumber, 2)) {
+                    listener.getLogger().println("Checking parameters of #" + buildNumber);
+                    String validateUrlString = this.buildGetUrl(jobName, securityToken) + "/" + buildNumber + "/api/json/";
+                    JSONObject validateResponse = sendHTTPCall(validateUrlString, "GET", build, listener);
+                    if (validateResponse == null) {
+                        listener.getLogger().println("Query failed.");
+                        continue;
                     }
-                    // This is the wrong build
-                    break;
-                }
+                    JSONArray actions = validateResponse.getJSONArray("actions");
+                    for (int i = 0; i < actions.size(); i++) {
+                        JSONObject action = actions.getJSONObject(i);
+                        if (!action.has("parameters")) continue;
+                        JSONArray parameters = action.getJSONArray("parameters");
+                        // Check if the parameters match
+                        if (compareParameters(listener, parameters, cleanedParams)) {
+                            // We now have a very high degree of confidence that this is the correct build.
+                            // It is still possible that this is a false positive if there are no parameters,
+                            // or multiple jobs use the same parameters.
+                            nextBuildNumber = buildNumber;
+                            break foundIt;
+                        }
+                        // This is the wrong build
+                        break;
+                    }
 
-                // Sleep for 'pollInterval' seconds.
-                // Sleep takes miliseconds so need to convert this.pollInterval to milisecopnds (x 1000)
-                try {
-                    Thread.sleep(this.pollInterval * 1000);
-                } catch (InterruptedException e) {
-                    this.failBuild(e, listener);
+                    // Sleep for 'pollInterval' seconds.
+                    // Sleep takes miliseconds so need to convert this.pollInterval to milisecopnds (x 1000)
+                    try {
+                        Thread.sleep(this.pollInterval * 1000);
+                    } catch (InterruptedException e) {
+                        this.failBuild(e, listener);
+                    }
                 }
             }
         }
+
         listener.getLogger().println("This job is build #[" + Integer.toString(nextBuildNumber) + "] on the remote server.");
         BuildInfoExporterAction.addBuildInfoExporterAction(build, jobName, nextBuildNumber, Result.NOT_BUILT);
         
@@ -1164,8 +1168,14 @@ public class RemoteBuildConfiguration extends Builder {
         try {
             JSONObject response = sendHTTPCall(remoteServerUrl, "GET", build, listener);
 
-            if(response.getJSONArray("actions").size() >= 1){
-                isParameterized = true;
+            JSONArray parameters = response.getJSONArray("actions");
+            if(parameters.size() >= 1){
+                for(int i = 0; i < parameters.size(); i++) {
+                    if(parameters.getJSONObject(i).has("parameterDefinitions") ) {
+                        isParameterized = true;
+                        break;
+                    }
+                }
             }
             
         } catch (IOException e) {


### PR DESCRIPTION
1. when remote trigger the first build, it will failed.
2. there is some mistake about whether the remote job is parameterized.
3. when the remote job is not parameterized, it doesn't need to compare the parameters.
4. when jenkins start with "gbk/gb2312/gb18030" encoding, the remote trigger step failed with exception "net.sf.json.JSONException", because of chinese garbled caused by reading the response of HTTPURLConnection with default encoding.