### PR TITLE
Revert "Do not encode the entire URL, only the job name"

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -1158,11 +1158,11 @@ public class RemoteBuildConfiguration extends Builder {
         //build the proper URL to inspect the remote job
         RemoteJenkinsServer remoteServer = this.findRemoteHost(this.getRemoteJenkinsName());
         String remoteServerUrl = remoteServer.getAddress().toString();
-        remoteServerUrl += "/job/" + encodeValue(jobName);
+        remoteServerUrl += "/job/" + jobName;
         remoteServerUrl += "/api/json";
         
         try {
-            JSONObject response = sendHTTPCall(remoteServerUrl, "GET", build, listener);
+            JSONObject response = sendHTTPCall(encodeValue(remoteServerUrl), "GET", build, listener);
 
             if(response.getJSONArray("actions").size() >= 1){
                 isParameterized = true;


### PR DESCRIPTION
This reverts commit a2360deb4d58bbb0f8df703c9e7d434bee82c228.