### PR TITLE
get remote job build number from the queue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,15 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.580</version>
+    <version>2.2</version>
   </parent>
+
+  <properties>
+    <jenkins.version>1.577</jenkins.version>
+    <java.level>7</java.level>
+    <jenkins-test-harness.version>2.1</jenkins-test-harness.version>
+    <findbugs.failOnError>false</findbugs.failOnError>
+  </properties>
 
   <artifactId>Parameterized-Remote-Trigger</artifactId>
   <version>2.2.3-SNAPSHOT</version>

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/ConnectionResponse.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/ConnectionResponse.java
@@ -1,0 +1,42 @@
+package org.jenkinsci.plugins.ParameterizedRemoteTrigger;
+
+import java.util.List;
+import java.util.Map;
+
+import net.sf.json.JSONObject;
+
+/**
+ * Class to store a connection response
+ *
+ * @author Alejandra Ferreiro Vidal
+ */
+public class ConnectionResponse
+{
+  private final Map<String,List<String>> response_header;
+  private final JSONObject response_object;
+
+  public ConnectionResponse(Map<String,List<String>> header, JSONObject response)
+  {
+    if (header == null || header.isEmpty())
+      throw new RuntimeException("There was no response-header in connection-response.");
+
+    this.response_header = header;
+    this.response_object = response;
+  }
+
+  public Map<String,List<String>> getResponseHeader()
+  {
+    return response_header;
+  }
+
+  public JSONObject getResponseObject()
+  {
+    return response_object;
+  }
+
+  public String getLocation()
+  {
+    if (!response_header.containsKey("Location")) return null;
+    return response_header.get("Location").get(0);
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJob.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJob.java
@@ -1,0 +1,35 @@
+package org.jenkinsci.plugins.ParameterizedRemoteTrigger;
+
+/**
+ * Class to store remote job data
+ *
+ * @author Alejandra Ferreiro Vidal
+ */
+public class RemoteJob
+{
+  final private int jobNumber;
+  final private String jobURL;
+
+  public RemoteJob(int jobNumber, String jobURL)
+  {
+    if (jobNumber < 1)
+      throw new RuntimeException("Remote job build number was not found.");
+
+    if (jobURL == null || jobURL.equals(""))
+      throw new RuntimeException("Remote job url was not found.");
+
+    this.jobNumber = jobNumber;
+    this.jobURL = jobURL;
+  }
+
+  public int getBuildNumber()
+  {
+    return jobNumber;
+  }
+
+  public String getURL()
+  {
+    return jobURL;
+  }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJobInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJobInfo.java
@@ -1,0 +1,72 @@
+package org.jenkinsci.plugins.ParameterizedRemoteTrigger;
+
+import net.sf.json.JSONObject;
+import hudson.AbortException;
+
+/**
+ * Class to store the queue response
+ *
+ * @author Alejandra Ferreiro Vidal
+ */
+public class RemoteJobInfo
+{
+  private JSONObject queueResponse;
+
+  public RemoteJobInfo(JSONObject queueResponse)
+  {
+    if (queueResponse == null)
+      throw new RuntimeException("No queue-response.");
+
+    this.queueResponse = queueResponse;
+  }
+
+  public boolean isBlocked()
+  {
+    return queueResponse.getBoolean("blocked");
+  }
+
+  public boolean isBuildable()
+  {
+    return queueResponse.getBoolean("buildable");
+  }
+
+  public boolean isPending()
+  {
+    return getOptionalBoolean("pending");
+  }
+
+  public boolean isCancelled()
+  {
+    return getOptionalBoolean("cancelled");
+  }
+
+  public String getWhy()
+  {
+    return queueResponse.getString("why");
+  }
+
+  public boolean isExecutable()
+  {
+    return (!isBlocked() && !isBuildable() && !isPending() && !isCancelled());
+  }
+
+  public RemoteJob getRemoteJob() throws AbortException
+  {
+    if (isExecutable()) {
+      JSONObject remoteJobInfo = queueResponse.getJSONObject("executable");
+      if (remoteJobInfo.isNullObject())
+        throw new AbortException("The attribute \"executable\" was not found. Unexpected response: " + queueResponse.toString());
+      return new RemoteJob(remoteJobInfo.getInt("number"), remoteJobInfo.getString("url"));
+    }
+    else {
+      return null;
+    }
+  }
+
+  private boolean getOptionalBoolean(String attribute)
+  {
+    if (queueResponse.containsKey(attribute))
+      return queueResponse.getBoolean(attribute);
+    else return false;
+  }
+}

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfigurationTest.java
@@ -34,6 +34,7 @@ public class RemoteBuildConfigurationTest {
                 "", true, null, null, false, true, 1);
         project.getBuildersList().add(remoteBuildConfiguration);
 
+        jenkinsRule.waitUntilNoActivity();
         jenkinsRule.buildAndAssertSuccess(project);
     }
 }


### PR DESCRIPTION
The Parameterized Remote Trigger Plugin is not able to identify the build number of the job that was triggered.

This solution gets the remote job's build number and the remote job's location checking the remote job's queue.

When the remote job is triggered, it gets from the response's header, the queue's location of the remote job, and supervises the queue item of the remote job, failing if the remote job is cancelled or getting the remote job's url and build number if the remote job is executed.

Furthermore, "org.jenkins-ci.plugins" was upgraded, because the previous version did not return the "executable" flag in the /queue/item/ query.

Change-Id: I596b00fa27b50ba3a340f4f0d1ff53ff9a4c002d

Signed-off-by: Alejandra Ferreiro Vidal <alejandra.ferreiro.vidal@sap.com>