### PR TITLE
save the raw http response for usage in other plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,9 @@ release.properties
 target
 *.releaseBackup
 *.swp
+
+# IntelliJ project files
+*.iml
+*.ipr
+*.iws
+.idea/

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/ConnectionResponse.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/ConnectionResponse.java
@@ -21,6 +21,9 @@ public class ConnectionResponse
     @Nullable @CheckForNull
     private final JSONObject body;
 
+    @Nullable @CheckForNull
+    private final String rawBody;
+
     @Nonnull
     private final int responseCode;
 
@@ -29,13 +32,15 @@ public class ConnectionResponse
     {
         this.header = header;
         this.body = body;
+        this.rawBody = null;
         this.responseCode = responseCode;
     }
 
-    public ConnectionResponse(@Nonnull Map<String, List<String>> header, @Nonnull int responseCode)
+    public ConnectionResponse(@Nonnull Map<String, List<String>> header, @Nullable String body, @Nonnull int responseCode)
     {
         this.header = header;
         this.body = null;
+        this.rawBody = body;
         this.responseCode = responseCode;
     }
 
@@ -46,6 +51,10 @@ public class ConnectionResponse
 
     public JSONObject getBody() {
         return body;
+    }
+
+    public String getRawBody() {
+        return rawBody;
     }
 
     public int getResponseCode() {

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -1072,8 +1072,9 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
                 //Seems like in Jenkins version 1.547, when using "/build" (job API for non-parameterized jobs), it returns a string indicating the status.
                 //But in newer versions of Jenkins, it just returns an empty response.
                 //So we need to compensate and check for both.
+                //In case of a non-JSON response, save the response as a raw String, to download other data types
                 if ( responseCode >= 400 || JSONUtils.mayBeJSON(response) == false) {
-                    return new ConnectionResponse(responseHeader, responseCode);
+                    return new ConnectionResponse(responseHeader, response, responseCode);
                 } else {
                     responseObject = (JSONObject) JSONSerializer.toJSON(response);
                 }

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -1034,7 +1034,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
      *            if the request fails due to an unknown host or unauthorized credentials, or
      *            if the request fails due to another reason and the number of attempts is exceeded.
      */
-    private ConnectionResponse sendHTTPCall(String urlString, String requestType, BuildContext context, int numberOfAttempts)
+    public ConnectionResponse sendHTTPCall(String urlString, String requestType, BuildContext context, int numberOfAttempts)
             throws IOException {
 
         int retryLimit = this.getConnectionRetryLimit();


### PR DESCRIPTION
We are using the parameterized remote trigger plugin quite heavily to trigger jobs and pull artifacts and other build data.
Currently the response type is limited to JSON. This PR changes the access level of the `sendHTTPCall `  method to public and saves the raw http response in  the `ConnectionResponse ` class.

@cashlalala What do u think?