### PR TITLE
 don't fail the build in case of an unstable remote build result

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -786,7 +786,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
           }
 
           // If build did not finish with 'success' or 'unstable' then fail build step.
-          if (buildInfo.getResult() != Result.SUCCESS && buildInfo.getResult() != Result.UNSTABLE)) {
+          if (buildInfo.getResult() != Result.SUCCESS && buildInfo.getResult() != Result.UNSTABLE) {
               // failBuild will check if the 'shouldNotFailBuild' parameter is set or not, so will decide how to
               // handle the failure.
               this.failBuild(new Exception("The remote job did not succeed."), context.logger);


### PR DESCRIPTION
The build result handling logic is quite hard, so that only success builds are not aborted. We have certain jobs, where we lookup for warnings and so on and set the build status to unstable.