### PR TITLE
Updated parameterized build detection

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -999,6 +999,14 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 					}
 				}
 			}
+
+			if (!isParameterized && remoteJobMetadata.getJSONArray("property").size() >= 1) {
+				for (Object obj : remoteJobMetadata.getJSONArray("property")) {
+					if (obj instanceof  JSONObject && ((JSONObject) obj).get("parameterDefinitions") != null) {
+						isParameterized = true;
+					}
+				}
+			}
 		} else {
 			throw new AbortException(
 					"Could not identify if job is parameterized. Job metadata not accessible or with unexpected content.");


### PR DESCRIPTION
Checks the property job metadata field in addition to the actions array

Fixes #JENKINS-52673