### PR TITLE
Update RemoteBuildConfiguration.java

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.ParameterizedRemoteTrigger;
 import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.apache.commons.lang.StringUtils.trimToEmpty;
 import static org.apache.commons.lang.StringUtils.trimToNull;
+import static org.apache.commons.lang.StringUtils.stripAll;
 import static org.jenkinsci.plugins.ParameterizedRemoteTrigger.utils.StringTools.NL;
 
 import java.io.BufferedReader;
@@ -304,7 +305,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 	 */
 	private List<String> getCleanedParameters(List<String> parameters) {
 		List<String> params = new ArrayList<String>(parameters);
-		params = StringUtils.stripAll(params);
+		params = stripAll(params);
 		removeEmptyElements(params);
 		removeCommentsFromParameters(params);
 		return params;

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -239,6 +239,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 		String params = getParameters();
 		if (!params.isEmpty()) {
 			String[] parameterArray = params.split("\n");
+			parameterArray = stripAll(parameterArray);
 			return new ArrayList<String>(Arrays.asList(parameterArray));
 		} else if (loadParamsFromFile) {
 			return loadExternalParameterFile(context);
@@ -305,7 +306,6 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 	 */
 	private List<String> getCleanedParameters(List<String> parameters) {
 		List<String> params = new ArrayList<String>(parameters);
-		params = stripAll(params);
 		removeEmptyElements(params);
 		removeCommentsFromParameters(params);
 		return params;

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -304,6 +304,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 	 */
 	private List<String> getCleanedParameters(List<String> parameters) {
 		List<String> params = new ArrayList<String>(parameters);
+		params = StringUtils.stripAll(params);
 		removeEmptyElements(params);
 		removeCommentsFromParameters(params);
 		return params;


### PR DESCRIPTION
When using triggerRemoteJob from pipeline, if we enter multiple parameters, by default, the pipeline script editor add multiple tabulation to indent the line correctly. When processing them we need to remove those unnecessary tabulation.