### PR TITLE
[FIX JENKINS-52810] Ensure older configurations work when deserialized.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -140,6 +140,12 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 			}
 		}
 		auth = null;
+		if (hostLocks == null) {
+			hostLocks = new HashMap<>();
+		}
+		if (hostPermits == null) {
+			hostPermits = new HashMap<>();
+		}
 		return this;
 	}
 	


### PR DESCRIPTION
When deserializing a job configuration from an older version,
the hostLocks and hostPermits fields will be null as they
were not present in the older versions.  This can cause a
NullPointerException when running a job with an older
configuration.

Fix this by ensuring older configurations get proper default
values for these fields, if missing.