### PR TITLE
Fix fails with poll interval value more than 5 min

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -692,9 +692,13 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 			context.logger.println("Waiting for remote build to be executed...");
 		}
 
+		int pollIntervalForQueuedItem = this.pollInterval;
+		if (pollIntervalForQueuedItem > DEFAULT_POLLINTERVALL) {
+			pollIntervalForQueuedItem = DEFAULT_POLLINTERVALL;
+		}
 		while (buildInfo.isQueued()) {
-			context.logger.println("Waiting for " + this.pollInterval + " seconds until next poll.");
-			Thread.sleep(this.pollInterval * 1000);
+			context.logger.println("Waiting for " + pollIntervalForQueuedItem + " seconds until next poll.");
+			Thread.sleep(pollIntervalForQueuedItem * 1000);
 			buildInfo = updateBuildInfo(buildInfo, context);
 			handle.setBuildInfo(buildInfo);
 		}


### PR DESCRIPTION
Fix releated to the issue:
https://issues.jenkins-ci.org/browse/JENKINS-55038

There is a problem when we try to use poll interval parameter's value
more than 300 seconds(5 minutes). We have a Jenkins pipeline which may
take from 30 to 60 minutes.

In some cases Jenkins `queued` item may move to the `pending` state as
it described here:
https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/Queue.java#L139

In such case the plugin use user specified poll interval time out value
to check `queued` item state:
https://github.com/jenkinsci/parameterized-remote-trigger-plugin/blob/master/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java#L696

But all `queued` items in the Jenkins have time to live only 5 minutes
as you can see it here:
https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/Queue.java#L218

As result we have triggered `build` on the remote Jenkins server but
failed build(`Max number of connection retries have been exeeded` error
from the plugin) on the main Jenkins server.

As fix we propose use default value of the poll interval(10 seconds) to
check `queued` item state. Because in the `pending` state the `queued`
item is staying only for a few seconds.