### PR TITLE
correct method name in docs

### DIFF
--- a/README_PipelineConfiguration.md
+++ b/README_PipelineConfiguration.md
@@ -95,7 +95,7 @@ The `Handle` object provides the following methods:
 - `RemoteBuildInfo getBuildInfo()` return information regarding the current remote build
 - `RemoteBuildStatus getBuildStatus()` returns the current remote build status
 - `Result getBuildResult()` return the result of the remote build
-- `BuildStatus getBuildStatusBlocking()` waits for completion and returns the build result
+- `RemoteBuildStatus updateBuildStatusBlocking()` waits for completion and returns the build result
 - `boolean isFinished()` true if the remote build finished
 - `boolean isQueued()` true if the job is queued but not yet running
 - `String toString()`
@@ -157,7 +157,7 @@ echo handle.getBuildStatus().toString();
 Even with `blockBuildUntilComplete: false` it is possible to wait synchronously until the remote job finished:
 ```
 def handle = triggerRemoteJob blockBuildUntilComplete: false, ...
-def status = handle.getBuildStatusBlocking()
+def status = handle.updateBuildStatusBlocking()
 ``` 
 
 :warning: Currently the plugin cannot log to the pipeline log directly if used in non-blocking mode. As workaround you can use `handle.lastLog()` after each command to get the log entries.

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/Handle.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/Handle.java
@@ -202,7 +202,7 @@ public class Handle implements Serializable {
     /**
      * Gets the current build status of the remote job.
      *
-     * @return {@link hudson.model.Result} the build result
+     * @return {@link org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob.RemoteBuildStatus} the build status
      */
     @Nonnull
     @Whitelisted
@@ -213,8 +213,7 @@ public class Handle implements Serializable {
     /**
      * Updates the current build status of the remote job.
      *
-     * @return {@link hudson.model.Result} the build result
-     *
+     * @return {@link org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob.RemoteBuildStatus} the build status
      * @throws IOException
      *            if there is an error retrieving the remote build number, or,
      *            if there is an error retrieving the remote build status, or,


### PR DESCRIPTION
**changes:**
- correct method name as changed in https://github.com/jenkinsci/parameterized-remote-trigger-plugin/pull/38
- correct return type