### PR TITLE
set the tree information for the api/json endpoint

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -838,7 +838,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 		}
 
 		// Only avoid url cache while loop inquiry
-		String buildUrlString = String.format("%sapi/json/?seed=%d", buildInfo.getBuildURL(),
+		String buildUrlString = String.format("%sapi/json/?tree=result&seed=%d", buildInfo.getBuildURL(),
 				System.currentTimeMillis());
 		JSONObject responseObject = doGet(buildUrlString, context).getBody();
 


### PR DESCRIPTION
This is to avoid requesting, having jenkins calculate and sending over the network the full jenkins json api when the only thing we are interested in is the 'result' key.
This is based on the best practices for handling the jenkins api