### PR TITLE
Added ability to accept untrusted certificates

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
@@ -3,17 +3,19 @@ package org.jenkinsci.plugins.ParameterizedRemoteTrigger;
 import static org.apache.commons.lang.StringUtils.trimToEmpty;
 
 import java.io.Serializable;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
+import javax.net.ssl.*;
 import java.net.URL;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.List;
 
 import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.Auth2;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.Auth2.Auth2Descriptor;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.NoneAuth;
+import org.jenkinsci.plugins.ParameterizedRemoteTrigger.utils.NaiveTrustManager;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -50,6 +52,7 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
     @CheckForNull
     private String     displayName;
     private boolean    hasBuildTokenRootSupport;
+    private boolean    trustAllCertificates;
     @CheckForNull
     private Auth2      auth2;
     @CheckForNull
@@ -77,6 +80,10 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
         return this;
     }
 
+    @DataBoundSetter
+    public void setTrustAllCertificates(boolean trustAllCertificates) {
+        this.trustAllCertificates = trustAllCertificates;
+    }
 
     @DataBoundSetter
     public void setDisplayName(String displayName)
@@ -145,12 +152,36 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
         return (DescriptorImpl) super.getDescriptor();
     }
 
+    public boolean getTrustAllCertificates() { return trustAllCertificates; }
+
 
     @Extension
     public static class DescriptorImpl extends Descriptor<RemoteJenkinsServer> {
 
         public String getDisplayName() {
             return "";
+        }
+
+        /**
+         * Sets the TrustManager to be a "NaiveTrustManager", allowing us to ignore untrusted certificates
+         * Will set the connection to null, if a key management error occurred.
+         *
+         * ATTENTION: THIS IS VERY DANGEROUS AND SHOULD ONLY BE USED IF YOU KNOW WHAT YOU DO!
+         * @param conn  The HttpsURLConnection you want to modify.
+         * @param trustAllCertificates  A boolean, gotten from the Remote Hosts description
+         */
+        public void makeConnectionTrustAllCertificates(HttpsURLConnection conn, boolean trustAllCertificates)
+                throws NoSuchAlgorithmException, KeyManagementException {
+            if (trustAllCertificates) {
+                SSLContext ctx = SSLContext.getInstance("TLS");
+                ctx.init(new KeyManager[0], new TrustManager[]{new NaiveTrustManager()}, new SecureRandom());
+                // SSLContext.setDefault(ctx);
+                conn.setSSLSocketFactory(ctx.getSocketFactory());
+
+                // Trust every hostname
+                HostnameVerifier allHostsValid = (hostname, session) -> true;
+                conn.setHostnameVerifier(allHostsValid);
+            }
         }
 
         /**
@@ -161,7 +192,7 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
          * @return FormValidation object
          */
         @Restricted(NoExternalUse.class)
-        public FormValidation doCheckAddress(@QueryParameter String address) {
+        public FormValidation doCheckAddress(@QueryParameter String address, @QueryParameter boolean trustAllCertificates) {
 
             URL host = null;
 
@@ -180,11 +211,22 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
 
             // check that the host is reachable
             try {
-                HttpURLConnection connection = (HttpURLConnection) host.openConnection();
-                connection.setConnectTimeout(5000);
-                connection.connect();
+                HttpsURLConnection conn = (HttpsURLConnection) host.openConnection();
+                try {
+                    makeConnectionTrustAllCertificates(conn, trustAllCertificates);
+                } catch (NoSuchAlgorithmException | KeyManagementException e) {
+                    return FormValidation.error(e, "A key management error occurred.");
+                }
+                conn.setConnectTimeout(5000);
+                conn.connect();
+
+                if (trustAllCertificates) {
+                    return FormValidation.warning(
+                            "Connection established! Accepting all certificates is potentially unsafe."
+                    );
+                }
             } catch (Exception e) {
-                return FormValidation.warning("Address looks good, but a connection could not be stablished.");
+                return FormValidation.warning("Address looks good, but a connection could not be established.");
             }
 
             return FormValidation.ok();

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
@@ -53,6 +53,8 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
     private String     displayName;
     private boolean    hasBuildTokenRootSupport;
     private boolean    trustAllCertificates;
+    private boolean    overrideTrustAllCertificates;
+
     @CheckForNull
     private Auth2      auth2;
     @CheckForNull
@@ -83,6 +85,11 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
     @DataBoundSetter
     public void setTrustAllCertificates(boolean trustAllCertificates) {
         this.trustAllCertificates = trustAllCertificates;
+    }
+
+    @DataBoundSetter
+    public void setOverrideTrustAllCertificates(boolean overrideTrustAllCertificates) {
+        this.overrideTrustAllCertificates = overrideTrustAllCertificates;
     }
 
     @DataBoundSetter
@@ -154,6 +161,8 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
 
     public boolean getTrustAllCertificates() { return trustAllCertificates; }
 
+    public boolean getOverrideTrustAllCertificates() { return overrideTrustAllCertificates; }
+
 
     @Extension
     public static class DescriptorImpl extends Descriptor<RemoteJenkinsServer> {
@@ -175,7 +184,6 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
             if (trustAllCertificates) {
                 SSLContext ctx = SSLContext.getInstance("TLS");
                 ctx.init(new KeyManager[0], new TrustManager[]{new NaiveTrustManager()}, new SecureRandom());
-                // SSLContext.setDefault(ctx);
                 conn.setSSLSocketFactory(ctx.getSocketFactory());
 
                 // Trust every hostname

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/RemoteBuildPipelineStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/RemoteBuildPipelineStep.java
@@ -104,6 +104,16 @@ public class RemoteBuildPipelineStep extends Step {
 	}
 
 	@DataBoundSetter
+	public void setTrustAllCertificates(boolean trustAllCertificates) {
+		remoteBuildConfig.setTrustAllCertificates(trustAllCertificates);
+	}
+
+	@DataBoundSetter
+	public void setOverrideTrustAllCertificates(boolean overrideTrustAllCertificates) {
+		remoteBuildConfig.setOverrideTrustAllCertificates(overrideTrustAllCertificates);
+	}
+
+	@DataBoundSetter
 	public void setPreventRemoteBuildQueue(boolean preventRemoteBuildQueue) {
 		remoteBuildConfig.setPreventRemoteBuildQueue(preventRemoteBuildQueue);
 	}
@@ -288,6 +298,14 @@ public class RemoteBuildPipelineStep extends Step {
 
 	public boolean getShouldNotFailBuild() {
 		return remoteBuildConfig.getShouldNotFailBuild();
+	}
+
+	public boolean getTrustAllCertificates() {
+		return remoteBuildConfig.getTrustAllCertificates();
+	}
+
+	public boolean getOverrideTrustAllCertificates() {
+		return remoteBuildConfig.getOverrideTrustAllCertificates();
 	}
 
 	public boolean getPreventRemoteBuildQueue() {

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/utils/HttpHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/utils/HttpHelper.java
@@ -12,12 +12,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
-import java.net.HttpURLConnection;
+import javax.net.ssl.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.Instant;
@@ -186,7 +189,7 @@ public class HttpHelper {
 		return cleanValue;
 	}
 
-	private static String readInputStream(HttpURLConnection connection) throws IOException {
+	private static String readInputStream(HttpsURLConnection connection) throws IOException {
 		BufferedReader rd = null;
 		try {
 
@@ -243,7 +246,7 @@ public class HttpHelper {
 				context.logger.println("reuse cached crumb: " + globalHost);
 				return jenkinsCrumb;
 			}
-			HttpURLConnection connection = getAuthorizedConnection(context, crumbProviderUrl, overrideAuth);
+			HttpsURLConnection connection = getAuthorizedConnection(context, crumbProviderUrl, overrideAuth);
 			int responseCode = connection.getResponseCode();
 			if (responseCode == 401) {
 				throw new UnauthorizedException(crumbProviderUrl);
@@ -277,7 +280,7 @@ public class HttpHelper {
 	 * @param context
 	 * @throws IOException
 	 */
-	private static void addCrumbToConnection(HttpURLConnection connection, BuildContext context, Auth2 overrideAuth,
+	private static void addCrumbToConnection(HttpsURLConnection connection, BuildContext context, Auth2 overrideAuth,
 			boolean isCacheEnabled) throws IOException {
 		String method = connection.getRequestMethod();
 		if (method != null && method.equalsIgnoreCase("POST")) {
@@ -288,7 +291,19 @@ public class HttpHelper {
 		}
 	}
 
-	private static HttpURLConnection getAuthorizedConnection(BuildContext context, URL url, Auth2 overrideAuth)
+	/**
+	 * Returns an authorized HttpsURLConnection
+	 * If the user wanted to trust all certificates, the TrustManager and HostVerifier of the connection
+	 * will be set properly.
+	 *
+	 * ATTENTION: THIS IS VERY DANGEROUS AND SHOULD ONLY BE USED IF YOU KNOW WHAT YOU DO!
+	 * @param context The build context
+	 * @param url The url to the remote build
+	 * @param overrideAuth
+	 * @return An authorized connection with or without a NaiveTrustManager
+	 * @throws IOException
+	 */
+	private static HttpsURLConnection getAuthorizedConnection(BuildContext context, URL url, Auth2 overrideAuth)
 			throws IOException {
 		URLConnection connection = context.effectiveRemoteServer.isUseProxy() ? ProxyConfiguration.open(url)
 				: url.openConnection();
@@ -302,8 +317,24 @@ public class HttpHelper {
 			// Set Authorization Header configured globally for remoteServer
 			serverAuth.setAuthorizationHeader(connection, context);
 		}
+		HttpsURLConnection conn = (HttpsURLConnection) connection;
 
-		return (HttpURLConnection) connection;
+		if (context.effectiveRemoteServer.getTrustAllCertificates()){
+			// Installing the naive manage
+			try {
+				SSLContext ctx = SSLContext.getInstance("TLS");
+				ctx.init(new KeyManager[0], new TrustManager[]{new NaiveTrustManager()}, new SecureRandom());
+				// SSLContext.setDefault(ctx);
+				conn.setSSLSocketFactory(ctx.getSocketFactory());
+
+				// Trust every hostname
+				HostnameVerifier allHostsValid = (hostname, session) -> true;
+				conn.setHostnameVerifier(allHostsValid);
+			} catch (NoSuchAlgorithmException | KeyManagementException e) {
+				context.logger.println("Unable to trust all certificates.");
+			}
+		}
+		return conn;
 	}
 
 	private static String getUrlWithoutParameters(String url) {
@@ -387,7 +418,6 @@ public class HttpHelper {
 	 * of a failed connection, the method calls it self recursively and increments
 	 * the number of attempts.
 	 *
-	 * @see sendHTTPCall
 	 * @param urlString
 	 *            the URL that needs to be called.
 	 * @param requestType
@@ -429,7 +459,7 @@ public class HttpHelper {
 		}
 
 		URL url = new URL(urlString);
-		HttpURLConnection conn = getAuthorizedConnection(context, url, overrideAuth);
+		HttpsURLConnection conn = getAuthorizedConnection(context, url, overrideAuth);
 
 		try {
 			conn.setDoInput(true);
@@ -440,7 +470,7 @@ public class HttpHelper {
 			// wait up to 5 seconds for the connection to be open
 			conn.setConnectTimeout(5000);
 			if (HTTP_POST.equalsIgnoreCase(requestType)) {
-				// use longer timeout during POST due to not performing retrys since POST is not idem-potent
+				// use longer timeout during POST due to not performing retries since POST is not idem-potent
 				conn.setReadTimeout(30000);
 				conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
 				conn.setRequestProperty("Content-Length", String.valueOf(postDataBytes.length));
@@ -491,7 +521,7 @@ public class HttpHelper {
 				// non-parameterized jobs), it returns a string indicating the status.
 				// But in newer versions of Jenkins, it just returns an empty response.
 				// So we need to compensate and check for both.
-				if (responseCode >= 400 || JSONUtils.mayBeJSON(response) == false) {
+				if (responseCode >= 400 || !JSONUtils.mayBeJSON(response)) {
 					return new ConnectionResponse(responseHeader, response, responseCode);
 				} else {
 					responseObject = (JSONObject) JSONSerializer.toJSON(response);
@@ -509,12 +539,12 @@ public class HttpHelper {
 			// If we have connectionRetryLimit set to > 0 then retry that many times.
 			if (numberOfAttempts <= retryLimit) {
 				context.logger.println(String.format(
-						"Connection to remote server failed %s, waiting for to retry - %s seconds until next attempt. URL: %s, parameters: %s",
+						"Connection to remote server failed %s, waiting to retry - %s seconds until next attempt. URL: %s, parameters: %s",
 						(responseCode == 0 ? "" : "[" + responseCode + "]"), pollInterval,
 						getUrlWithoutParameters(urlString), parmsString));
 
 				// Sleep for 'pollInterval' seconds.
-				// Sleep takes miliseconds so need to convert this.pollInterval to milisecopnds
+				// Sleep takes milliseconds so need to convert this.pollInterval to milliseconds
 				// (x 1000)
 				try {
 					// Could do with a better way of sleeping...

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/utils/NaiveTrustManager.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/utils/NaiveTrustManager.java
@@ -1,0 +1,18 @@
+package org.jenkinsci.plugins.ParameterizedRemoteTrigger.utils;
+
+import javax.net.ssl.*;
+import java.security.cert.X509Certificate;
+
+// Trust every server
+public class NaiveTrustManager implements X509TrustManager {
+    @Override
+    public void checkClientTrusted(X509Certificate[] arg0, String arg1) {}
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] arg0, String arg1) {}
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+        return null;
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration/config.jelly
@@ -14,10 +14,11 @@
     </f:section>
 
     <f:section title="Job Info">
+
         <f:entry title="Do not fail if remote fails" field="shouldNotFailBuild">
             <f:checkbox />
         </f:entry>
-        
+
         <f:entry title="Abort remote job if current job was aborted" field="abortTriggeredJob">
             <f:checkbox />
         </f:entry>
@@ -62,6 +63,13 @@
         <f:entry title="Disable the step" field="disabled">
             <f:checkbox />
         </f:entry>
+
+        <f:optionalBlock field="overrideTrustAllCertificates" title="Override trust all certificates" inline="true">
+          <f:entry title="Trust all certificates" field="trustAllCertificates">
+            <f:checkbox />
+          </f:entry>
+        </f:optionalBlock>
+
         <f:optionalBlock title="Load parameters from external file (this will cause the job to ignore the text field above)" field="loadParamsFromFile" inline="true">
             <f:entry title="Parameter file path + name (all paths are relative to the current workspace)" field="parameterFile">
                 <f:textbox />

--- a/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration/help-trustAllCertificates.html
+++ b/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration/help-trustAllCertificates.html
@@ -1,0 +1,21 @@
+<div>
+    <div style="font-weight: bolder; text-decoration: underline">
+        Trust all certificates
+    </div>
+
+    <p>
+        It is possible to override/rewrite the 'Trust all certificate'-setting for each Job separately.
+        Setting this checkbox to 'true' will result in accepting all certificates for the given Job.
+    </p>
+
+    <div>
+    If your remote Jenkins host has a
+    <a href="https://en.wikipedia.org/wiki/Self-signed_certificate" target="_blank">
+        self-signed certificate
+    </a>
+    or its certificate is not trusted, you may want to enable this option.
+    It will accept untrusted certificates for the given host.
+    </div>
+
+    <p><strong>This is unsafe and should only be used for testing or if you trust the host.</strong></p>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer/config.jelly
@@ -8,6 +8,9 @@
         <f:checkbox />
     </f:entry>
 
+    <f:entry title="Trust all certificates" field="trustAllCertificates">
+        <f:checkbox />
+    </f:entry>
 
     <f:dropdownDescriptorSelector field="auth2" title="Authentication" descriptors="${descriptor.getAuth2Descriptors()}" default="${descriptor.getDefaultAuth2Descriptor()}"/>
 

--- a/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer/config.jelly
@@ -9,8 +9,9 @@
     </f:entry>
 
     <f:entry title="Trust all certificates" field="trustAllCertificates">
-        <f:checkbox />
+      <f:checkbox />
     </f:entry>
+
 
     <f:dropdownDescriptorSelector field="auth2" title="Authentication" descriptors="${descriptor.getAuth2Descriptors()}" default="${descriptor.getDefaultAuth2Descriptor()}"/>
 

--- a/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer/help-trustAllCertificates.html
+++ b/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer/help-trustAllCertificates.html
@@ -1,0 +1,16 @@
+<div>
+    <div style="font-weight: bolder; text-decoration: underline">
+        Trust all certificates
+    </div>
+
+    <div>
+        If your remote Jenkins host has a
+        <a href="https://en.wikipedia.org/wiki/Self-signed_certificate" target="_blank">
+            self-signed certificate
+        </a>
+        or its certificate is not trusted, you may want to enable this option.
+        It will accept untrusted certificates for the given host.
+    </div>
+
+    <p><strong>This is unsafe and should only be used for testing or if you trust the host.</strong></p>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/RemoteBuildPipelineStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/RemoteBuildPipelineStep/config.jelly
@@ -15,6 +15,7 @@
     </f:section>
 
     <f:section title="Job Info">
+
         <f:entry title="Do not fail if remote fails" field="shouldNotFailBuild">
             <f:checkbox />
         </f:entry>
@@ -63,6 +64,13 @@
         <f:entry title="Disable the step" field="disabled">
             <f:checkbox />
         </f:entry>
+
+        <f:optionalBlock field="overrideTrustAllCertificates" title="Override trust all certificates" inline="true">
+          <f:entry title="Trust all certificates" field="trustAllCertificates">
+            <f:checkbox />
+          </f:entry>
+        </f:optionalBlock>
+
         <f:optionalBlock title="Load parameters from external file (this will cause the job to ignore the text field above)" field="loadParamsFromFile" inline="true">
             <f:entry title="Parameter file path + name (all paths are relative to the current workspace)" field="parameterFile">
                  <f:textbox />

--- a/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/RemoteBuildPipelineStep/help-trustAllCertificates.html
+++ b/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/RemoteBuildPipelineStep/help-trustAllCertificates.html
@@ -1,0 +1,21 @@
+<div>
+    <div style="font-weight: bolder; text-decoration: underline">
+        Trust all certificates
+    </div>
+
+    <p>
+        It is possible to override/rewrite the 'Trust all certificate'-setting for each Job separately.
+        Setting this checkbox to 'true' will result in accepting all certificates for the given Job.
+    </p>
+
+    <div>
+    If your remote Jenkins host has a
+    <a href="https://en.wikipedia.org/wiki/Self-signed_certificate" target="_blank">
+        self-signed certificate
+    </a>
+    or its certificate is not trusted, you may want to enable this option.
+    It will accept untrusted certificates for the given host.
+    </div>
+
+    <p><strong>This is unsafe and should only be used for testing or if you trust the host.</strong></p>
+</div>


### PR DESCRIPTION
**Added**
- A "NaiveTrustManager", which allows to bypass certificate checks
  -> Enables us to accept any certificate
- TrustAllCertificates option for Jenkins Admins (globally) and Jenkins users (per job/pipeline)
- Overwriting the 'global' TrustAllCertificates option per job and pipeline is possible