### PR TITLE
Added support for views

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -289,7 +289,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 	 * Reads a file from the jobs workspace, and loads the list of parameters from
 	 * with in it. It will also call ```getCleanedParameters``` before returning.
 	 *
-	 * @param build
+	 * @param BuildContext context
 	 * @return List<String> of build parameters
 	 */
 	private List<String> loadExternalParameterFile(BuildContext context) {
@@ -337,7 +337,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 	 * that no type of character encoding is happening at this step. All encoding
 	 * happens in the "buildUrlQueryString" method.
 	 *
-	 * @param List <String> parameters
+	 * @param List<String> parameters
 	 * @return List<String> of build parameters
 	 */
 	private List<String> getCleanedParameters(List<String> parameters) {

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.ParameterizedRemoteTrigger;
 
+import static java.lang.Math.min;
 import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.apache.commons.lang.StringUtils.trimToEmpty;
 import static org.apache.commons.lang.StringUtils.trimToNull;
@@ -510,7 +511,12 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 		if (isEmpty(jobUrl))
 			return null;
 		if (FormValidationUtils.isURL(jobUrl)) {
-			int index = jobUrl.indexOf("/job/");
+			int index;
+			if (jobUrl.contains("/view/")) {
+				index = min(jobUrl.indexOf("/view/"), jobUrl.indexOf("/job/"));
+			} else {
+				index = jobUrl.indexOf("/job/");
+			}
 			if (index < 0)
 				throw new MalformedURLException("Expected '/job/' element in job URL but was: " + jobUrl);
 			return jobUrl.substring(0, index);

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfigurationTest.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import hudson.model.*;
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.RemoteBuildConfiguration.DescriptorImpl;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.NullAuth;
@@ -37,6 +36,7 @@ import hudson.model.FreeStyleProject;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.StringParameterDefinition;
 import hudson.model.User;
+import hudson.model.ListView;
 import hudson.security.HudsonPrivateSecurityRealm;
 import hudson.security.SecurityRealm;
 import hudson.security.AuthorizationStrategy.Unsecured;

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfigurationTest.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import hudson.model.*;
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.RemoteBuildConfiguration.DescriptorImpl;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.NullAuth;
@@ -518,6 +519,17 @@ public class RemoteBuildConfigurationTest {
 		parms.put("parameterName1", TestConst.garbled5KString1);
 		parms.put("parameterName2", TestConst.garbled5KString2);
 		_testRemoteBuild(true, true, remoteProject, parms);
+	}
+
+	@Test
+	public void testRemoteViewBuild() throws Exception {
+		disableAuth();
+
+		FreeStyleProject remoteProject = jenkinsRule.createFreeStyleProject("test-job");
+		ListView view = new ListView("test-view", jenkinsRule.getInstance());
+		view.add(remoteProject);
+		jenkinsRule.getInstance().addView(view);
+		_testRemoteBuild(false, false, remoteProject);
 	}
 
 }


### PR DESCRIPTION
Currently the plugin fails to get the root URL of a remote job if it belongs in a view at the root level. This change should enable support for remote job in views. I've added a new test case for a job in a view. Let me know if any other testing is required?