### PR TITLE
[JENKINS-56770] Do not serialize semaphores

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,11 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.5</version>
+    <version>3.50</version>
   </parent>
 
   <properties>
-    <jenkins.version>1.642.3</jenkins.version>
+    <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   </parent>
 
   <properties>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>1.642.3</jenkins.version>
     <java.level>8</java.level>
   </properties>
 

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -121,7 +121,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 	private boolean abortTriggeredJob;
 	private boolean disabled;
 
-	private Map<String, Semaphore> hostLocks = new HashMap<>();
+	private transient Map<String, Semaphore> hostLocks = new HashMap<>();
 	private Map<String, Integer> hostPermits = new HashMap<>();
 
 	private static Logger logger = Logger.getLogger(RemoteBuildConfiguration.class.getName());


### PR DESCRIPTION
- Set min jenkins to 2.60.3 this is the first version of jenkins to require java 8
- Bump plugin pom
- Mark the map with semaphore values as transient so it does not get serialized