### PR TITLE
Add support for Bearer Token Authentication

### DIFF
--- a/README_PipelineConfiguration.md
+++ b/README_PipelineConfiguration.md
@@ -74,6 +74,9 @@ Authentication can be configured globally in the system configuration or set/ove
 The following authentication types are available:
 - **Token Authentication** The specified user id and Jenkins API token is used.<br>
   ```auth: TokenAuth(apiToken: '<theApiToken>', userName: '<userName>')```
+- **Bearer Token Authentication** The specified token is inserted to a "Authentication: Bearer" header in REST API requests.<br>
+  This is useful when the Jenkins deployment is fronted by a token authentication mechanism (such as when running on Red Hat OpenShift)<br>
+  ```auth: BearerTokenAuth(token: '<token>')```
 - **Credentials Authentication** The specified Jenkins Credentials are used. This can be either user/password or user/API Token.<br>
   ```auth: CredentialsAuth(credentials: '<credentialId>')```
 - **No Authentication** No Authorization header will be sent, independent of the global 'remote host' settings.<br>

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/BearerTokenAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/BearerTokenAuth.java
@@ -84,6 +84,8 @@ public class BearerTokenAuth extends Auth2 {
         if (token == null) {
             if (other.token == null) {
                 return true;
+            } else {
+                return false;
             }
         }
         return token.equals(other.token);

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/BearerTokenAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/BearerTokenAuth.java
@@ -1,0 +1,94 @@
+package org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2;
+
+import java.io.IOException;
+import java.net.URLConnection;
+
+import org.jenkinsci.Symbol;
+
+import org.jenkinsci.plugins.ParameterizedRemoteTrigger.BuildContext;
+import org.jenkinsci.plugins.ParameterizedRemoteTrigger.utils.Base64Utils;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import hudson.Extension;
+import hudson.model.Item;
+
+
+public class BearerTokenAuth extends Auth2 {
+
+    //private static final long serialVersionUID = 051380141338287L;
+
+    @Extension
+    public static final Auth2Descriptor DESCRIPTOR = new BearerTokenAuthDescriptor();
+
+    private String token;
+
+    @DataBoundConstructor
+    public BearerTokenAuth() {
+        this.token = null;
+    }
+
+    @DataBoundSetter
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public String getToken() {
+        return this.token;
+    }
+
+    @Override
+    public void setAuthorizationHeader(URLConnection connection, BuildContext context) throws IOException {
+        connection.setRequestProperty("Authorization", "Bearer: " + getToken());
+    }
+
+    @Override
+    public String toString() {
+        return "'" + getDescriptor().getDisplayName() + "'";
+    }
+
+    @Override
+    public String toString(Item item) {
+        return toString();
+    }
+
+    @Override
+    public Auth2Descriptor getDescriptor() {
+        return DESCRIPTOR;
+    }
+
+    @Symbol("BearerTokenAuth")
+    public static class BearerTokenAuthDescriptor extends Auth2Descriptor {
+        @Override
+        public String getDisplayName() {
+            return "Bearer Token Authentication";
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((token == null) ? 0 : token.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (!this.getClass().isInstance(obj))
+            return false;
+        BearerTokenAuth other = (BearerTokenAuth) obj;
+        if (token == null) {
+            if (other.token != null)
+                return false;
+        } else if (!token.equals(other.token)) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/BearerTokenAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/BearerTokenAuth.java
@@ -6,7 +6,6 @@ import java.net.URLConnection;
 import org.jenkinsci.Symbol;
 
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.BuildContext;
-import org.jenkinsci.plugins.ParameterizedRemoteTrigger.utils.Base64Utils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -16,7 +15,7 @@ import hudson.model.Item;
 
 public class BearerTokenAuth extends Auth2 {
 
-    //private static final long serialVersionUID = 051380141338287L;
+    private static final long serialVersionUID = 3614172320192170597L;
 
     @Extension
     public static final Auth2Descriptor DESCRIPTOR = new BearerTokenAuthDescriptor();
@@ -83,12 +82,10 @@ public class BearerTokenAuth extends Auth2 {
             return false;
         BearerTokenAuth other = (BearerTokenAuth) obj;
         if (token == null) {
-            if (other.token != null)
-                return false;
-        } else if (!token.equals(other.token)) {
-            return false;
+            if (other.token == null) {
+                return true;
+            }
         }
-        return true;
+        return token.equals(other.token);
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/Auth2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/Auth2Test.java
@@ -10,6 +10,20 @@ import org.junit.Test;
 public class Auth2Test {
 
     @Test
+    public void testBearerTokenAuthCloneBehaviour() throws CloneNotSupportedException {
+        BearerTokenAuth original = new BearerTokenAuth();
+        original.setToken("original");
+        BearerTokenAuth clone = (BearerTokenAuth)original.clone();
+        verifyEqualsHashCode(original, clone);
+
+        //Test changing clone
+        clone.setToken("changed");
+        verifyEqualsHashCode(original, clone, false);
+        assertEquals("original", original.getToken());
+        assertEquals("changed", clone.getToken());
+    }
+
+    @Test
     public void testCredentialsAuthCloneBehaviour() throws CloneNotSupportedException {
         CredentialsAuth original = new CredentialsAuth();
         original.setCredentials("original");


### PR DESCRIPTION
When Jenkins is running on top of OpenShift, bearer token authentication is used for all REST API calls.

This means the API requests are authenticated via a header like:
`Authorization: Bearer <Kubernetes/OpenShift Token>`

I've been using these modifications to the plugin to trigger remote jobs on a master deployed on OpenShift with the OpenShift authentication enabled.

Example usage in a pipeline:
```
    def jobParameters = [[$class: StringParameterValue, name: "someParam", value: "someValue"]]
    // Translate the params into a string
    def paramsString = ""
    for (Map p : jobParameters) {
        paramsString = paramsString + "\n${p['name']}=${p['value'].toString()}"
    }

    withCredentials([
        string(credentialsId: remoteCredentials, variable: "TOKEN"),
        string(credentialsId: remoteHostname, variable: "REMOTE_HOSTNAME")
    ]) {
        triggerRemoteJob(
            job: "https://${REMOTE_HOSTNAME}/job/path/to/job",
            parameters: paramsString,
            auth: BearerTokenAuth(token: TOKEN)
        )
    }
```