### PR TITLE
add handler.updateBuildStatus() to non-blocking example

### DIFF
--- a/README_PipelineConfiguration.md
+++ b/README_PipelineConfiguration.md
@@ -153,6 +153,7 @@ def handle = triggerRemoteJob(
 while( !handle.isFinished() ) {
     echo 'Current Status: ' + handle.getBuildStatus().toString();
     sleep 5
+    handle.updateBuildStatus()
 }
 echo handle.getBuildStatus().toString();
 ```


### PR DESCRIPTION
Currently, if the example is used as is, the `buildStatus` doesn't really change which leads to endless polling