### PR TITLE
Override remote build URL protocol and port

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfigurationTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.spy;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -451,6 +452,16 @@ public class RemoteBuildConfigurationTest {
         assertEquals("xxx", RemoteBuildConfiguration.removeHashParameters("xxx"));
         assertEquals("http://test:8080/MyJob", RemoteBuildConfiguration.removeHashParameters("http://test:8080/MyJob#asdsad"));
         assertEquals("xxx", RemoteBuildConfiguration.removeHashParameters("xxx#zzz"));
+    }
+
+    @Test @WithoutJenkins
+    public void testGenerateEffectiveRemoteBuildURL() throws Exception {
+        URL remoteBuildURL = new URL("http://test:8080/job/Abc/3/");
+
+        assertEquals(new URL("https://foobar:8443/job/Abc/3/"), RemoteBuildConfiguration.generateEffectiveRemoteBuildURL(remoteBuildURL, "https://foobar:8443"));
+        assertEquals(new URL("http://foobar:8888/job/Abc/3/"), RemoteBuildConfiguration.generateEffectiveRemoteBuildURL(remoteBuildURL, "http://foobar:8888"));
+        assertEquals(new URL("https://foobar/job/Abc/3/"), RemoteBuildConfiguration.generateEffectiveRemoteBuildURL(remoteBuildURL, "https://foobar"));
+        assertEquals(new URL("http://foobar/job/Abc/3/"), RemoteBuildConfiguration.generateEffectiveRemoteBuildURL(remoteBuildURL, "http://foobar"));
     }
 
     @Test @WithoutJenkins


### PR DESCRIPTION
When the remoteJenkinsUrl specifies a different protocol or port than the Jenkins API reports, the build will fail because the Build URL is wrong. This is because only the hostname is replaced on the URL returned from the Jenkins API.

My Jenkins server is accessed from two networks, one of which has a reverse proxy with only SSL. When builds are triggered on the SSL side, the remote job will start but it cannot poll for the build status because the build URL is wrong (http instead of https).

I fixed the issue by copying the request path onto the remoteJenkinsURL

```
remoteJenkinsUrl: 'https://external-jenkins:8443'
Before change:
http://internal-jenkins/job/MyProject/3/ -> http://external-jenkins/job/MyProject/3/

After change:
http://internal-jenkins/job/MyProject/3/ -> https://external-jenkins:8443/job/MyProject/3/
```
