### PR TITLE
Set restriction on pollinterval for items in queue

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/Handle.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/Handle.java
@@ -357,7 +357,7 @@ public class Handle implements Serializable {
         PrintStreamWrapper log = new PrintStreamWrapper();
         try {
             BuildContext context = new BuildContext(log.getPrintStream(), effectiveRemoteServer, this.currentItem);
-            return remoteBuildConfiguration.doGet(fileUrl.toString(), context).getBody();
+            return remoteBuildConfiguration.doGet(fileUrl.toString(), context, getBuildStatus()).getBody();
         } finally {
             lastLog = log.getContent();
         }

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/RemoteBuildPipelineStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/RemoteBuildPipelineStep.java
@@ -32,6 +32,7 @@ import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.BasicBuildContext;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.BuildContext;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.RemoteBuildConfiguration;
+import org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob.RemoteBuildStatus;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.RemoteJenkinsServer;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.Auth2;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.Auth2.Auth2Descriptor;
@@ -313,7 +314,7 @@ public class RemoteBuildPipelineStep extends Step {
 	}
 
 	public int getPollInterval() {
-		return remoteBuildConfig.getPollInterval();
+		return remoteBuildConfig.getPollInterval(RemoteBuildStatus.RUNNING);
 	}
 
 	public boolean getBlockBuildUntilComplete() {

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/utils/RestUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/utils/RestUtils.java
@@ -9,6 +9,7 @@ import org.jenkinsci.plugins.ParameterizedRemoteTrigger.RemoteBuildConfiguration
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.exceptions.ExceedRetryLimitException;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.pipeline.Handle;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob.RemoteBuildInfo;
+import org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob.RemoteBuildStatus;
 
 /*
  * Going to migrate all rest APIs to here
@@ -23,7 +24,7 @@ public class RestUtils {
 		String cancelQueueUrl = String.format("%s/queue/cancelItem?id=%s", rootUrl, handle.getQueueId());
 		ConnectionResponse resp = null;
 		try {
-			resp = HttpHelper.tryPost(cancelQueueUrl, context, null, remoteConfig.getPollInterval() * 2, 0,
+			resp = HttpHelper.tryPost(cancelQueueUrl, context, null, remoteConfig.getPollInterval(RemoteBuildStatus.QUEUED) * 2, 0,
 					remoteConfig.getAuth2(), remoteConfig.getLock(cancelQueueUrl), remoteConfig.isUseCrumbCache());
 		} catch (ExceedRetryLimitException e) {
 			// Due to https://issues.jenkins-ci.org/browse/JENKINS-21311, we can't tell
@@ -40,7 +41,7 @@ public class RestUtils {
 
 		RemoteBuildInfo buildInfo = handle.getBuildInfo();
 		String stopJobUrl = String.format("%sstop", buildInfo.getBuildURL());
-		ConnectionResponse resp = HttpHelper.tryPost(stopJobUrl, context, null, remoteConfig.getPollInterval(),
+		ConnectionResponse resp = HttpHelper.tryPost(stopJobUrl, context, null, remoteConfig.getPollInterval(buildInfo.getStatus()),
 				remoteConfig.getConnectionRetryLimit(), remoteConfig.getAuth2(), remoteConfig.getLock(stopJobUrl),
 				remoteConfig.isUseCrumbCache());
 		context.logger.println(String.format("Remote Job:%s was aborted!", buildInfo.getBuildURL()));

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfigurationTest.java
@@ -22,6 +22,7 @@ import org.jenkinsci.plugins.ParameterizedRemoteTrigger.RemoteBuildConfiguration
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.NullAuth;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.TokenAuth;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.pipeline.RemoteBuildPipelineStep;
+import org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob.RemoteBuildStatus;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -178,7 +179,7 @@ public class RemoteBuildConfigurationTest {
       assertEquals(false, config.getOverrideAuth());
       assertEquals("", config.getParameterFile());
       assertEquals("", config.getParameters());
-      assertEquals(10, config.getPollInterval());
+      assertEquals(10, config.getPollInterval(RemoteBuildStatus.RUNNING));
       assertEquals(false, config.getPreventRemoteBuildQueue());
       assertEquals(null, config.getRemoteJenkinsName());
       assertEquals(false, config.getShouldNotFailBuild());


### PR DESCRIPTION
The poll interval depends from context of remote build.
Regression fix for:
https://issues.jenkins-ci.org/browse/JENKINS-55038
All items in Jenkins queue cache have TTL 5 minutes
https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/Queue.java#L217-L222