### PR TITLE
Setup CookieHandler

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -12,6 +12,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.Serializable;
+import java.net.CookieHandler;
+import java.net.CookieManager;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -133,6 +135,8 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 
 	@DataBoundConstructor
 	public RemoteBuildConfiguration() {
+		CookieManager cookieManager = new CookieManager();
+		CookieHandler.setDefault(cookieManager);
 		pollInterval = DEFAULT_POLLINTERVALL;
 	}
 


### PR DESCRIPTION
This commit sets up a CookieManager and makes the system-wide CookieHandler use it.

Starting from Jenkins LTS 2.176.2 a valid Web Session for which the crumb was issued is also required unless configured otherwise.