### PR TITLE
Only use token macro on user supplied values

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/CredentialsAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/CredentialsAuth.java
@@ -122,7 +122,7 @@ public class CredentialsAuth extends Auth2 {
         Jenkins jenkins = Jenkins.getInstance();
         if (jenkins != null) {
             Item item = jenkins.getItem(context.currentItem, jenkins.getItem("/"));
-            String authHeaderValue = Base64Utils.generateAuthorizationHeaderValue(AUTHTYPE_BASIC, getUserName(item), getPassword(item), context);
+            String authHeaderValue = Base64Utils.generateAuthorizationHeaderValue(AUTHTYPE_BASIC, getUserName(item), getPassword(item), context, false);
             connection.setRequestProperty("Authorization", authHeaderValue);
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/TokenAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/TokenAuth.java
@@ -50,7 +50,7 @@ public class TokenAuth extends Auth2 {
 
     @Override
     public void setAuthorizationHeader(URLConnection connection, BuildContext context) throws IOException {
-        String authHeaderValue = Base64Utils.generateAuthorizationHeaderValue(AUTHTYPE_BASIC, getUserName(), getApiToken(), context);
+        String authHeaderValue = Base64Utils.generateAuthorizationHeaderValue(AUTHTYPE_BASIC, getUserName(), getApiToken(), context, true);
         connection.setRequestProperty("Authorization", authHeaderValue);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/Handle.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/Handle.java
@@ -19,7 +19,6 @@ import org.jenkinsci.plugins.ParameterizedRemoteTrigger.RemoteBuildConfiguration
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.RemoteJenkinsServer;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob.RemoteBuildInfo;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob.RemoteBuildStatus;
-import org.jenkinsci.plugins.ParameterizedRemoteTrigger.utils.HttpHelper;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 
 import hudson.model.Result;

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/utils/Base64Utils.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/utils/Base64Utils.java
@@ -34,6 +34,8 @@ public class Base64Utils
      *           the user password.
      * @param context
      *            the context of this Builder/BuildStep.
+     * @param applyMacro
+     *            boolean to control if macro replacements occur
      * @return the base64 encoded authorization.
      * @throws IOException
      *            if there is a failure while replacing token macros, or
@@ -41,13 +43,15 @@ public class Base64Utils
      */
     @Nonnull
     public static String generateAuthorizationHeaderValue(String authType, String user, String password,
-                BuildContext context) throws IOException
+                BuildContext context, boolean applyMacro) throws IOException
     {
         if (isEmpty(user)) throw new IllegalArgumentException("user null or empty");
         if (password == null) throw new IllegalArgumentException("password null"); // is empty password allowed for Basic Auth?
         String authTypeKey = getAuthType(authType);
         String tuple = user + ":" + password;
-        tuple = TokenMacroUtils.applyTokenMacroReplacements(tuple, context);
+        if (applyMacro) {
+            tuple = TokenMacroUtils.applyTokenMacroReplacements(tuple, context);
+        }
         String encodedTuple = Base64Utils.encode(tuple);
         return authTypeKey + " " + encodedTuple;
     }

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/utils/Base64UtilsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/utils/Base64UtilsTest.java
@@ -1,0 +1,15 @@
+package org.jenkinsci.plugins.ParameterizedRemoteTrigger.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class Base64UtilsTest {
+
+    @Test
+    public void testGenAuthNoToken() throws Exception {
+        String result = Base64Utils.generateAuthorizationHeaderValue(Base64Utils.AUTHTYPE_BASIC, "user", "$password", null, false);
+        assertEquals("Basic dXNlcjokcGFzc3dvcmQ=", result);
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: Raihaan Shouhell <raihaan.shouhell@autodesk.com>

CredentialsAuth uses the jenkins cred store for its credentials it should not require env var expansion. This allows passwords to contain the dollar sign

PTAL: @cashlalala 