### PR TITLE
Point pom to github so plugin documentation is updated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <packaging>hpi</packaging>
   <name>Parameterized Remote Trigger Plugin</name>
   <description>This plugin gives you the ability to trigger parameterized builds on a remote Jenkins server as part of your build.</description>
-  <url>http://wiki.jenkins-ci.org/display/JENKINS/Parameterized+Remote+Trigger+Plugin</url>
+  <url>https://github.com/jenkinsci/parameterized-remote-trigger-plugin</url>
 
   <licenses>
     <license>


### PR DESCRIPTION
Point the pom to github so plugin documentation on https://plugins.jenkins.io/Parameterized-Remote-Trigger/ is properly updated with the repositories contents