### PR TITLE
retrieve only needed "doGetting" build fields

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -879,7 +879,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 		}
 
 		// Only avoid url cache while loop inquiry
-		String buildUrlString = String.format("%sapi/json/?seed=%d", buildInfo.getBuildURL(),
+		String buildUrlString = String.format("%sapi/json/?tree=result,building&seed=%d", buildInfo.getBuildURL(),
 				System.currentTimeMillis());
 		JSONObject responseObject = doGet(buildUrlString, context, buildInfo.getStatus()).getBody();
 


### PR DESCRIPTION
As the author of this PR https://github.com/jenkinsci/parameterized-remote-trigger-plugin/pull/55 doesn't answer to the proposed fix in his fork, here is the appropriate change fixing the infinite loop due to the "building" status which was not retrieved in the original PR.

Retrieving only requested fields meaning result & building which are used later in the code will greatly improve performances specially in large builds archiving lot of files or others contents in the returned build api/json payload  as all these others informations are not needed & will increase the json marshaling & transfer time sometimes to some MB & lot of minutes.  

As side effect, without that optimization if the get call spends more than the timeout duration due to the size of data , it will ends with some failed retries & a final failure status while everything was smooth/ok on the jenkins server side.