### PR TITLE
[JENKINS-63819] make sure maxConn is 1 by default

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -1019,7 +1019,10 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 	}
 
 	public int getMaxConn() {
-		return maxConn;
+		if (maxConn > 0)
+			return maxConn;
+		else
+			return 1;
 	}
 
 	/**


### PR DESCRIPTION
[JENKINS-63819](https://issues.jenkins-ci.org/browse/JENKINS-63819) There may be a cleaner way to achieve this but I haven't been able to find any. Just setting maxConn to 1 in the class or the constructor doesn't help.
