### PR TITLE
Allow use `triggerRemoteJob` step with `agent none`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -341,7 +341,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 					parameterList.add(sCurrentLine);
 				}
 			} else {
-				context.logger.println("[WARNING] workspace is null");
+				throw new AbortException("Workspace is null but parameter file is used. Looks like this step was started with \"agent: none\"");
 			}
 		} catch (InterruptedException | IOException e) {
 			context.logger.println(String.format("[WARNING] Failed loading parameters: %s", e.getMessage()));

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/RemoteBuildPipelineStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/RemoteBuildPipelineStep.java
@@ -54,7 +54,6 @@ import org.kohsuke.stapler.QueryParameter;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.FilePath;
-import hudson.Launcher;
 import hudson.model.Descriptor;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -200,7 +199,7 @@ public class RemoteBuildPipelineStep extends Step {
 		@Override
 		public Set<? extends Class<?>> getRequiredContext() {
 			Set<Class<?>> set = new HashSet<Class<?>>();
-			Collections.addAll(set, Run.class, FilePath.class, Launcher.class, TaskListener.class);
+			Collections.addAll(set, Run.class, TaskListener.class);
 			return set;
 		}
 


### PR DESCRIPTION
Looks like agent used only if `loadParamsFromFile` attribute defined, but now we always need hold agent for remote job.