### PR TITLE
Improve parameters handling

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -106,7 +106,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 
 	/**
 	 * We need to keep this for compatibility - old config deserialization!
-	 * 
+	 *
 	 * @deprecated since 2.3.0-SNAPSHOT - use {@link Auth2} instead.
 	 */
 	private transient List<Auth> auth;
@@ -373,7 +373,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 	 * @param List<String> parameters
 	 * @return List<String> of build parameters
 	 */
-	private List<String> getCleanedParameters(List<String> parameters) {
+	List<String> getCleanedParameters(List<String> parameters) {
 		List<String> params = new ArrayList<String>(parameters);
 		removeEmptyElements(params);
 		removeCommentsFromParameters(params);
@@ -660,7 +660,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 	 * @throws IOException          if there is an error triggering the remote job.
 	 * @throws InterruptedException if any thread has interrupted the current
 	 *                              thread.
-	 * 
+	 *
 	 */
 	public Handle performTriggerAndGetQueueId(BuildContext context) throws IOException, InterruptedException {
 		List<String> cleanedParams = getCleanedParameters(getParameterList(context));
@@ -1276,7 +1276,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 		 * /** Performs on-the-fly validation of the form field 'name'.
 		 *
 		 * @param value This parameter receives the value that the user has typed.
-		 * 
+		 *
 		 * @return Indicates the outcome of the validation. This is sent to the browser.
 		 */
 		/*

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/FileParameters.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/FileParameters.java
@@ -1,0 +1,118 @@
+package org.jenkinsci.plugins.ParameterizedRemoteTrigger.parameters2;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.joining;
+
+import javax.annotation.Nonnull;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Map;
+import java.util.Objects;
+
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.ParameterizedRemoteTrigger.BuildContext;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import hudson.AbortException;
+import hudson.Extension;
+import hudson.FilePath;
+
+public class FileParameters extends JobParameters {
+
+	private static final long serialVersionUID = 3614172320192170597L;
+
+	@Extension
+	public static final FileParametersDescriptor DESCRIPTOR = new FileParametersDescriptor();
+
+	private String filePath;
+
+	@DataBoundConstructor
+	public FileParameters() {
+		this.filePath = null;
+	}
+
+	public FileParameters(String filePath) {
+		this.filePath = filePath;
+	}
+
+	@DataBoundSetter
+	public void setFilePath(final String filePath) {
+		this.filePath = filePath;
+	}
+
+	public String getFilePath() {
+		return filePath;
+	}
+
+	@Override
+	public String toString() {
+		return "(" + getClass().getSimpleName() + ") " + filePath;
+	}
+
+	@Override
+	public FileParametersDescriptor getDescriptor() {
+		return DESCRIPTOR;
+	}
+
+	@Override
+	public Map<String, String> getParametersMap(final BuildContext context) throws AbortException {
+		final String parametersAsString = readParametersFile(context);
+		return JobParameters.parseStringParameters(parametersAsString);
+	}
+
+	private String readParametersFile(final BuildContext context) throws AbortException {
+		if (context.workspace == null) {
+			throw new AbortException("Workspace is null but parameter file is used. Looks like this step was started with \"agent: none\"");
+		}
+
+		BufferedReader reader = null;
+		try {
+			final FilePath absoluteFilePath = context.workspace.child(getFilePath());
+			context.logger.printf("Loading parameters from file %s%n", absoluteFilePath.getRemote());
+
+			reader = new BufferedReader(new InputStreamReader(absoluteFilePath.read(), UTF_8));
+			return reader.lines().collect(joining("\n"));
+
+		} catch (final InterruptedException | IOException e) {
+			context.logger.printf("[WARNING] Failed loading parameters: %s%n", e.getMessage());
+			return "";
+
+		} finally {
+			try {
+				if (reader != null) {
+					reader.close();
+				}
+			} catch (final IOException ex) {
+				ex.printStackTrace();
+			}
+		}
+	}
+
+	@Symbol("FileParameters")
+	public static class FileParametersDescriptor extends ParametersDescriptor {
+		@Nonnull
+		@Override
+		public String getDisplayName() {
+			return "File parameters";
+		}
+	}
+
+	@Override
+	public boolean equals(final Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		final FileParameters that = (FileParameters) o;
+		return Objects.equals(filePath, that.filePath);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(filePath);
+	}
+}

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/JobParameters.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/JobParameters.java
@@ -1,0 +1,82 @@
+package org.jenkinsci.plugins.ParameterizedRemoteTrigger.parameters2;
+
+import static java.util.stream.Collectors.toMap;
+
+import java.io.Serializable;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Predicate;
+
+import org.jenkinsci.plugins.ParameterizedRemoteTrigger.BuildContext;
+
+import hudson.AbortException;
+import hudson.DescriptorExtensionList;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import jenkins.model.Jenkins;
+
+public abstract class JobParameters extends AbstractDescribableImpl<JobParameters> implements Serializable, Cloneable {
+
+	private static final DescriptorExtensionList<JobParameters, ParametersDescriptor> ALL =
+			DescriptorExtensionList.createDescriptorList(Jenkins.getInstance(), JobParameters.class);
+
+	public static DescriptorExtensionList<JobParameters, ParametersDescriptor> all() {
+		return ALL;
+	}
+
+	public static JobParameters migrateOldParameters(final String parameters, final String parameterFile) {
+		if (parameterFile != null) {
+			return new FileParameters(parameterFile);
+		}
+
+		if (parameters != null) {
+			return new StringParameters(parameters);
+		}
+
+		return new MapParameters();
+	}
+
+	public static Map<String, String> parseStringParameters(final String parametersAsString) {
+		return Arrays.stream(parametersAsString.split("\\n"))
+				.filter(not(JobParameters::isBlankLine))
+				.filter(not(JobParameters::isCommentedLine))
+				.filter(JobParameters::containsEqualSign)
+				.map(JobParameters::splitParameterLine)
+				.collect(toMap(Entry::getKey, Entry::getValue));
+	}
+
+	private static <T> Predicate<T> not(Predicate<T> t) {
+		return t.negate();
+	}
+
+	private static boolean isBlankLine(String line) {
+		return line.trim().isEmpty();
+	}
+
+	private static boolean isCommentedLine(String line) {
+		return line.trim().startsWith("#");
+	}
+
+	private static boolean containsEqualSign(String line) {
+		return line.contains("=");
+	}
+
+	private static Entry<String, String> splitParameterLine(String line) {
+		final int firstIndexOfEqualSign = line.indexOf("=");
+		return new AbstractMap.SimpleEntry<>(
+				line.substring(0, firstIndexOfEqualSign),
+				line.substring(firstIndexOfEqualSign + 1)
+		);
+	}
+
+	public static abstract class ParametersDescriptor extends Descriptor<JobParameters> { }
+
+	public abstract Map<String, String> getParametersMap(final BuildContext context) throws AbortException;
+
+	@Override
+	public JobParameters clone() throws CloneNotSupportedException {
+		return (JobParameters) super.clone();
+	}
+}

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/MapParameter.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/MapParameter.java
@@ -1,0 +1,86 @@
+package org.jenkinsci.plugins.ParameterizedRemoteTrigger.parameters2;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.util.Objects;
+
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+
+public class MapParameter extends AbstractDescribableImpl<MapParameter> implements Cloneable, Serializable {
+
+	@Extension
+	public static final MapParameterDescriptor DESCRIPTOR = new MapParameterDescriptor();
+
+	private String name;
+	private String value;
+
+	@DataBoundConstructor
+	public MapParameter() {
+		this("", "");
+	}
+
+	public MapParameter(String name, String value) {
+		this.name = name;
+		this.value = value;
+	}
+
+	@DataBoundSetter
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@DataBoundSetter
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	@Override
+	public MapParameter clone() throws CloneNotSupportedException {
+		return (MapParameter) super.clone();
+	}
+
+	@Override
+	public Descriptor<MapParameter> getDescriptor() {
+		return DESCRIPTOR;
+	}
+
+	@Symbol("MapParameter")
+	public static class MapParameterDescriptor extends Descriptor<MapParameter> {
+		@Nonnull
+		@Override
+		public String getDisplayName() {
+			return "Map parameter";
+		}
+	}
+
+	@Override
+	public boolean equals(final Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		final MapParameter that = (MapParameter) o;
+		return Objects.equals(name, that.name) && Objects.equals(value, that.value);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name, value);
+	}
+}

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/MapParameters.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/MapParameters.java
@@ -1,0 +1,101 @@
+package org.jenkinsci.plugins.ParameterizedRemoteTrigger.parameters2;
+
+import static java.util.stream.Collectors.toMap;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.ParameterizedRemoteTrigger.BuildContext;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import hudson.Extension;
+
+public class MapParameters extends JobParameters {
+
+	private static final long serialVersionUID = 3614172320192170597L;
+
+	@Extension
+	public static final MapParametersDescriptor DESCRIPTOR = new MapParametersDescriptor();
+
+	private final List<MapParameter> parameters = new ArrayList<>();
+
+	@DataBoundConstructor
+	public MapParameters() {}
+
+	public MapParameters(@NonNull Map<String, String> parametersMap) {
+		setParametersMap(parametersMap);
+	}
+
+	@DataBoundSetter
+	public void setParameters(final List<MapParameter> parameters) {
+		this.parameters.clear();
+		if (parameters != null) {
+			this.parameters.addAll(parameters);
+		}
+	}
+
+	public void setParametersMap(final Map<String, String> parametersMap) {
+		this.parameters.clear();
+		if (parametersMap != null) {
+			parametersMap
+					.entrySet()
+					.stream()
+					.map(entry -> new MapParameter(entry.getKey(), entry.getValue()))
+					.forEach(parameters::add);
+		}
+	}
+
+	public List<MapParameter> getParameters() {
+		return parameters;
+	}
+
+	@Override
+	public String toString() {
+		return "(" + getClass().getSimpleName() + ") " + parameters;
+	}
+
+	@Override
+	public MapParametersDescriptor getDescriptor() {
+		return DESCRIPTOR;
+	}
+
+	@Override
+	public Map<String, String> getParametersMap(final BuildContext context) {
+		return parameters
+				.stream()
+				.collect(toMap(MapParameter::getName, MapParameter::getValue));
+	}
+
+	@Symbol("MapParameters")
+	public static class MapParametersDescriptor extends ParametersDescriptor {
+		@Nonnull
+		@Override
+		public String getDisplayName() {
+			return "Map parameters";
+		}
+	}
+
+	@Override
+	public boolean equals(final Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		final MapParameters that = (MapParameters) o;
+		return Objects.equals(parameters, that.parameters);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(parameters);
+	}
+}

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/StringParameters.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/StringParameters.java
@@ -1,0 +1,81 @@
+package org.jenkinsci.plugins.ParameterizedRemoteTrigger.parameters2;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+import java.util.Objects;
+
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.ParameterizedRemoteTrigger.BuildContext;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import hudson.Extension;
+
+public class StringParameters extends JobParameters {
+
+	private static final long serialVersionUID = 3614172320192170597L;
+
+	@Extension
+	public static final StringParametersDescriptor DESCRIPTOR = new StringParametersDescriptor();
+
+	private String parameters;
+
+	@DataBoundConstructor
+	public StringParameters() {
+		this.parameters = null;
+	}
+
+	public StringParameters(String parameters) {
+		this.parameters = parameters;
+	}
+
+	@DataBoundSetter
+	public void setParameters(final String parameters) {
+		this.parameters = parameters;
+	}
+
+	public String getParameters() {
+		return parameters;
+	}
+
+	@Override
+	public String toString() {
+		return "(" + getClass().getSimpleName() + ") " + parameters;
+	}
+
+	@Override
+	public StringParametersDescriptor getDescriptor() {
+		return DESCRIPTOR;
+	}
+
+	@Override
+	public Map<String, String> getParametersMap(final BuildContext context) {
+		return JobParameters.parseStringParameters(parameters);
+	}
+
+	@Symbol("StringParameters")
+	public static class StringParametersDescriptor extends ParametersDescriptor {
+		@Nonnull
+		@Override
+		public String getDisplayName() {
+			return "String parameters";
+		}
+	}
+
+	@Override
+	public boolean equals(final Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		final StringParameters that = (StringParameters) o;
+		return Objects.equals(parameters, that.parameters);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(parameters);
+	}
+}

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/RemoteBuildPipelineStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/RemoteBuildPipelineStep.java
@@ -22,21 +22,22 @@
 
 package org.jenkinsci.plugins.ParameterizedRemoteTrigger.pipeline;
 
+import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.Nonnull;
-
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.BasicBuildContext;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.BuildContext;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.RemoteBuildConfiguration;
-import org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob.RemoteBuildStatus;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.RemoteJenkinsServer;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.Auth2;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.Auth2.Auth2Descriptor;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.NullAuth;
+import org.jenkinsci.plugins.ParameterizedRemoteTrigger.parameters2.JobParameters;
+import org.jenkinsci.plugins.ParameterizedRemoteTrigger.parameters2.MapParameters;
+import org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob.RemoteBuildStatus;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.utils.FormValidationUtils;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.utils.FormValidationUtils.AffectedField;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.utils.FormValidationUtils.RemoteURLCombinationsResult;
@@ -144,23 +145,13 @@ public class RemoteBuildPipelineStep extends Step {
 	}
 
 	@DataBoundSetter
-	public void setParameters(String parameters) {
-		remoteBuildConfig.setParameters(parameters);
+	public void setParameters2(JobParameters parameters2) {
+		remoteBuildConfig.setParameters2(parameters2);
 	}
 
 	@DataBoundSetter
 	public void setEnhancedLogging(boolean enhancedLogging) {
 		remoteBuildConfig.setEnhancedLogging(enhancedLogging);
-	}
-
-	@DataBoundSetter
-	public void setLoadParamsFromFile(boolean loadParamsFromFile) {
-		remoteBuildConfig.setLoadParamsFromFile(loadParamsFromFile);
-	}
-
-	@DataBoundSetter
-	public void setParameterFile(String parameterFile) {
-		remoteBuildConfig.setParameterFile(parameterFile);
 	}
 
 	@DataBoundSetter
@@ -172,7 +163,7 @@ public class RemoteBuildPipelineStep extends Step {
 	public void setUseCrumbCache(boolean useCrumbCache) {
 		remoteBuildConfig.setUseCrumbCache(useCrumbCache);
 	}
-	
+
 	@DataBoundSetter
 	public void setDisabled(boolean disabled) {
 		remoteBuildConfig.setDisabled(disabled);
@@ -198,7 +189,7 @@ public class RemoteBuildPipelineStep extends Step {
 
 		@Override
 		public Set<? extends Class<?>> getRequiredContext() {
-			Set<Class<?>> set = new HashSet<Class<?>>();
+			Set<Class<?>> set = new HashSet<>();
 			Collections.addAll(set, Run.class, TaskListener.class);
 			return set;
 		}
@@ -251,8 +242,16 @@ public class RemoteBuildPipelineStep extends Step {
 			return Auth2.all();
 		}
 
+		public static List<JobParameters.ParametersDescriptor> getParametersDescriptors() {
+			return JobParameters.all();
+		}
+
 		public static Auth2Descriptor getDefaultAuth2Descriptor() {
 			return NullAuth.DESCRIPTOR;
+		}
+
+		public static JobParameters.ParametersDescriptor getDefaultParametersDescriptor() {
+			return MapParameters.DESCRIPTOR;
 		}
 	}
 
@@ -283,7 +282,7 @@ public class RemoteBuildPipelineStep extends Step {
 					handle = remoteBuildConfig.performTriggerAndGetQueueId(context);
 					if (remoteBuildConfig.getBlockBuildUntilComplete()) {
 						remoteBuildConfig.performWaitForBuild(context, handle);
-					}	
+					}
 				}
 
 			} catch (InterruptedException e) {
@@ -342,20 +341,12 @@ public class RemoteBuildPipelineStep extends Step {
 		return remoteBuildConfig.getToken();
 	}
 
-	public String getParameters() {
-		return remoteBuildConfig.getParameters();
+	public JobParameters getParameters2() {
+		return remoteBuildConfig.getParameters2();
 	}
 
 	public boolean getEnhancedLogging() {
 		return remoteBuildConfig.getEnhancedLogging();
-	}
-
-	public boolean getLoadParamsFromFile() {
-		return remoteBuildConfig.getLoadParamsFromFile();
-	}
-
-	public String getParameterFile() {
-		return remoteBuildConfig.getParameterFile();
 	}
 
 	public int getConnectionRetryLimit() {
@@ -381,10 +372,9 @@ public class RemoteBuildPipelineStep extends Step {
 	public Auth2 getAuth() {
 		return remoteBuildConfig.getAuth2();
 	}
-	
+
 	public boolean isDisabled() {
 		return remoteBuildConfig.isDisabled();
 	}
-
 
 }

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/utils/TokenMacroUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/utils/TokenMacroUtils.java
@@ -1,43 +1,39 @@
 package org.jenkinsci.plugins.ParameterizedRemoteTrigger.utils;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.BasicBuildContext;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 
-public class TokenMacroUtils
-{
+public class TokenMacroUtils {
 
-    public static String applyTokenMacroReplacements(String input, BasicBuildContext context) throws IOException
-    {
+    public static String applyTokenMacroReplacements(String input, BasicBuildContext context) throws IOException {
         try {
             if (isUseTokenMacro(context)) {
                 return TokenMacro.expandAll(context.run, context.workspace, context.listener, input);
             }
-        }
-        catch (MacroEvaluationException e) {
+        } catch (MacroEvaluationException e) {
             throw new IOException(e);
-        }
-        catch (InterruptedException e) {
+        } catch (InterruptedException e) {
             throw new IOException(e);
         }
         return input;
     }
 
-    public static List<String> applyTokenMacroReplacements(List<String> inputs, BasicBuildContext context) throws IOException
-    {
-        List<String> outputs = new ArrayList<String>();
-        for (String input : inputs) {
-            outputs.add(applyTokenMacroReplacements(input, context));
+    public static Map<String, String> applyTokenMacroReplacements(Map<String, String> input, BasicBuildContext context)
+            throws IOException {
+
+        Map<String, String> output = new LinkedHashMap<>();
+        for (Map.Entry<String, String> entry : input.entrySet()) {
+            output.put(entry.getKey(), applyTokenMacroReplacements(entry.getValue(), context));
         }
-        return outputs;
+        return output;
     }
 
-    public static boolean isUseTokenMacro(BasicBuildContext context)
-    {
+    public static boolean isUseTokenMacro(BasicBuildContext context) {
         return context != null && context.run != null && context.workspace != null && context.listener != null;
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration/config.jelly
@@ -1,8 +1,8 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 
     <f:section title="Server Info">
-        <f:entry title="Select a remote host" >
+        <f:entry title="Select a remote host">
             <f:select field="remoteJenkinsName" />
         </f:entry>
 
@@ -10,7 +10,7 @@
             <f:textbox />
         </f:entry>
 
-        <f:dropdownDescriptorSelector field="auth2" title="Override credentials" descriptors="${descriptor.getAuth2Descriptors()}" default="${descriptor.getDefaultAuth2Descriptor()}"/>
+        <f:dropdownDescriptorSelector field="auth2" title="Override credentials" descriptors="${descriptor.getAuth2Descriptors()}" default="${descriptor.getDefaultAuth2Descriptor()}" />
     </f:section>
 
     <f:section title="Job Info">
@@ -22,13 +22,13 @@
         <f:entry title="Abort remote job if current job was aborted" field="abortTriggeredJob">
             <f:checkbox />
         </f:entry>
-        
+
         <f:entry title="Wait to trigger remote builds until no other builds are running." field="preventRemoteBuildQueue">
             <f:checkbox />
         </f:entry>
 
         <f:entry title="Poll Interval (seconds)" field="pollInterval">
-             <f:number clazz="positive-number" min="1" step="1" default="10" />
+            <f:number clazz="positive-number" min="1" step="1" default="10" />
         </f:entry>
 
         <f:entry title="Block until the remote triggered projects finish their builds." field="blockBuildUntilComplete">
@@ -43,10 +43,8 @@
             <f:password />
         </f:entry>
 
-        <f:entry title="Parameters" field="parameters">
-            <f:textarea />
-        </f:entry>
-        
+        <f:dropdownDescriptorSelector field="parameters2" title="Parameters" descriptors="${descriptor.getParametersDescriptors()}" default="${descriptor.getDefaultParametersDescriptor()}" />
+
         <f:entry title="Max connection" field="maxConn">
             <f:textbox default="1" />
         </f:entry>
@@ -55,7 +53,7 @@
             <f:checkbox />
         </f:entry>
         <f:entry title="Enable remote server crumb cache" field="useCrumbCache">
-            <f:checkbox default="true"/>
+            <f:checkbox default="true" />
         </f:entry>
         <f:entry title="Enable remote job info. cache" field="useJobInfoCache">
             <f:checkbox default="true" />
@@ -65,14 +63,8 @@
         </f:entry>
 
         <f:optionalBlock field="overrideTrustAllCertificates" title="Override trust all certificates" inline="true">
-          <f:entry title="Trust all certificates" field="trustAllCertificates">
-            <f:checkbox />
-          </f:entry>
-        </f:optionalBlock>
-
-        <f:optionalBlock title="Load parameters from external file (this will cause the job to ignore the text field above)" field="loadParamsFromFile" inline="true">
-            <f:entry title="Parameter file path + name (all paths are relative to the current workspace)" field="parameterFile">
-                <f:textbox />
+            <f:entry title="Trust all certificates" field="trustAllCertificates">
+                <f:checkbox />
             </f:entry>
         </f:optionalBlock>
     </f:section>

--- a/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/FileParameters/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/FileParameters/config.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+
+    <f:entry title="File path">
+        <f:textbox field="filePath" />
+    </f:entry>
+
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/MapParameter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/MapParameter/config.jelly
@@ -1,0 +1,11 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+
+    <f:entry title="Name">
+        <f:textbox field="name" />
+    </f:entry>
+    <f:entry title="Value">
+        <f:textarea field="value" />
+    </f:entry>
+
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/MapParameters/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/MapParameters/config.jelly
@@ -1,0 +1,14 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+
+    <f:entry title="Parameters">
+        <f:repeatableProperty field="parameters">
+            <f:block>
+                <div align="right">
+                    <f:repeatableDeleteButton />
+                </div>
+            </f:block>
+        </f:repeatableProperty>
+    </f:entry>
+
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/StringParameters/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/StringParameters/config.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+
+    <f:entry title="Parameters" field="parameters">
+        <f:textarea />
+    </f:entry>
+
+</j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfigurationTest.java
@@ -4,9 +4,12 @@ import static java.lang.String.join;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toMap;
 import static org.jenkinsci.plugins.ParameterizedRemoteTrigger.utils.StringTools.NL_UNIX;
+import static org.jenkinsci.plugins.ParameterizedRemoteTrigger.utils.StringTools.NL_UNIX;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doReturn;
@@ -25,6 +28,8 @@ import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.RemoteBuildConfiguration.DescriptorImpl;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.NullAuth;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.TokenAuth;
+import org.jenkinsci.plugins.ParameterizedRemoteTrigger.parameters2.JobParameters;
+import org.jenkinsci.plugins.ParameterizedRemoteTrigger.parameters2.MapParameters;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.pipeline.RemoteBuildPipelineStep;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob.RemoteBuildStatus;
 import org.junit.Assert;
@@ -53,117 +58,112 @@ import jenkins.model.Jenkins;
 
 public class RemoteBuildConfigurationTest {
 
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
+	@Rule
+	public JenkinsRule jenkinsRule = new JenkinsRule();
 
-    private User testUser;
-    private String testUserToken;
+	private User testUser;
+	private String testUserToken;
 
-    private void disableAuth() {
-        jenkinsRule.jenkins.setAuthorizationStrategy(Unsecured.UNSECURED);
-        jenkinsRule.jenkins.setSecurityRealm(SecurityRealm.NO_AUTHENTICATION);
-        jenkinsRule.jenkins.setCrumbIssuer(null);
-    }
+	private void disableAuth() {
+		jenkinsRule.jenkins.setAuthorizationStrategy(Unsecured.UNSECURED);
+		jenkinsRule.jenkins.setSecurityRealm(SecurityRealm.NO_AUTHENTICATION);
+		jenkinsRule.jenkins.setCrumbIssuer(null);
+	}
 
-    private void enableAuth() throws IOException {
-        MockAuthorizationStrategy mockAuth = new MockAuthorizationStrategy();
-        jenkinsRule.jenkins.setAuthorizationStrategy(mockAuth);
+	private void enableAuth() throws IOException {
+		MockAuthorizationStrategy mockAuth = new MockAuthorizationStrategy();
+		jenkinsRule.jenkins.setAuthorizationStrategy(mockAuth);
 
-        HudsonPrivateSecurityRealm hudsonPrivateSecurityRealm = new HudsonPrivateSecurityRealm(false, false, null);
-        jenkinsRule.jenkins.setSecurityRealm(hudsonPrivateSecurityRealm); //jenkinsRule.createDummySecurityRealm());
-        testUser = hudsonPrivateSecurityRealm.createAccount("test", "test");
-        testUserToken = testUser.getProperty(jenkins.security.ApiTokenProperty.class).getApiToken();
+		HudsonPrivateSecurityRealm hudsonPrivateSecurityRealm = new HudsonPrivateSecurityRealm(false, false, null);
+		jenkinsRule.jenkins.setSecurityRealm(hudsonPrivateSecurityRealm); //jenkinsRule.createDummySecurityRealm());
+		testUser = hudsonPrivateSecurityRealm.createAccount("test", "test");
+		testUserToken = testUser.getProperty(jenkins.security.ApiTokenProperty.class).getApiToken();
 
-        mockAuth.grant(Jenkins.ADMINISTER).everywhere().toAuthenticated();
-    }
+		mockAuth.grant(Jenkins.ADMINISTER).everywhere().toAuthenticated();
+	}
 
+	@Test
+	public void testRemoteBuild() throws Exception {
+		disableAuth();
+		_testRemoteBuild(false);
+	}
 
-    @Test
-    public void testRemoteBuild() throws Exception {
-        disableAuth();
-        _testRemoteBuild(false);
-    }
+	@Test
+	public void testRemoteBuildWithAuthentication() throws Exception {
+		enableAuth();
+		_testRemoteBuild(true);
+	}
 
-    @Test
-    public void testRemoteBuildWithAuthentication() throws Exception {
-        enableAuth();
-        _testRemoteBuild(true);
-    }
-
-    @Test
-    public void testRemoteBuildWithCrumb() throws Exception {
-        disableAuth();
-        jenkinsRule.jenkins.setCrumbIssuer(new DefaultCrumbIssuer(false));
-        _testRemoteBuild(false);
-    }
+	@Test
+	public void testRemoteBuildWithCrumb() throws Exception {
+		disableAuth();
+		jenkinsRule.jenkins.setCrumbIssuer(new DefaultCrumbIssuer(false));
+		_testRemoteBuild(false);
+	}
 
 	private void _testRemoteBuild(boolean authenticate, boolean withParam, FreeStyleProject remoteProject) throws Exception {
 		Map<String, String> parms = new HashMap<>();
 		parms.put("parameterName1", "value1");
 		parms.put("parameterName2", "value2");
-        this._testRemoteBuild(authenticate, withParam, remoteProject, parms);
-    }
+		this._testRemoteBuild(authenticate, withParam, remoteProject, parms);
+	}
 
-	private void _testRemoteBuild(boolean authenticate, boolean withParam, FreeStyleProject remoteProject, Map<String, String> parms) throws Exception {
+	private void _testRemoteBuild(boolean authenticate, boolean withParam, FreeStyleProject remoteProject, Map<String, String> params) throws Exception {
 
-        String remoteUrl = jenkinsRule.getURL().toString();
-        RemoteJenkinsServer remoteJenkinsServer = new RemoteJenkinsServer();
-        remoteJenkinsServer.setDisplayName("JENKINS");
-        remoteJenkinsServer.setAddress(remoteUrl);
-        RemoteBuildConfiguration.DescriptorImpl descriptor =
-                jenkinsRule.jenkins.getDescriptorByType(RemoteBuildConfiguration.DescriptorImpl.class);
-        descriptor.setRemoteSites(remoteJenkinsServer);
+		String remoteUrl = jenkinsRule.getURL().toString();
+		RemoteJenkinsServer remoteJenkinsServer = new RemoteJenkinsServer();
+		remoteJenkinsServer.setDisplayName("JENKINS");
+		remoteJenkinsServer.setAddress(remoteUrl);
+		RemoteBuildConfiguration.DescriptorImpl descriptor =
+				jenkinsRule.jenkins.getDescriptorByType(RemoteBuildConfiguration.DescriptorImpl.class);
+		descriptor.setRemoteSites(remoteJenkinsServer);
 
-        FreeStyleProject project = jenkinsRule.createFreeStyleProject();
-        RemoteBuildConfiguration configuration = new RemoteBuildConfiguration();
-        configuration.setJob(remoteProject.getFullName());
-        configuration.setRemoteJenkinsName(remoteJenkinsServer.getDisplayName());
-        configuration.setPreventRemoteBuildQueue(false);
-        configuration.setBlockBuildUntilComplete(true);
-        configuration.setPollInterval(1);
-        configuration.setHttpGetReadTimeout(1000);
-        configuration.setHttpPostReadTimeout(1000);
-        configuration.setUseCrumbCache(false);
-        configuration.setUseJobInfoCache(false);
-        configuration.setEnhancedLogging(true);
-        configuration.setTrustAllCertificates(true);
-        if (withParam){
-        	String parmString = "";
-        	for (Map.Entry<String, String> p : parms.entrySet()) {
-        		parmString += p.getKey() + "=" + p.getValue() + NL_UNIX;
-        	}
-        	configuration.setParameters(parmString);
-        }
-        if(authenticate) {
-            TokenAuth tokenAuth = new TokenAuth();
-            tokenAuth.setUserName(testUser.getId());
-            tokenAuth.setApiToken(Secret.fromString(testUserToken));
-            configuration.setAuth2(tokenAuth);
-        }
+		FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+		RemoteBuildConfiguration configuration = new RemoteBuildConfiguration();
+		configuration.setJob(remoteProject.getFullName());
+		configuration.setRemoteJenkinsName(remoteJenkinsServer.getDisplayName());
+		configuration.setPreventRemoteBuildQueue(false);
+		configuration.setBlockBuildUntilComplete(true);
+		configuration.setPollInterval(1);
+		configuration.setHttpGetReadTimeout(1000);
+		configuration.setHttpPostReadTimeout(1000);
+		configuration.setUseCrumbCache(false);
+		configuration.setUseJobInfoCache(false);
+		configuration.setEnhancedLogging(true);
+		configuration.setTrustAllCertificates(true);
+		if (withParam) {
+			configuration.setParameters2(new MapParameters(params));
+		}
+		if (authenticate) {
+			TokenAuth tokenAuth = new TokenAuth();
+			tokenAuth.setUserName(testUser.getId());
+			tokenAuth.setApiToken(Secret.fromString(testUserToken));
+			configuration.setAuth2(tokenAuth);
+		}
 
-        project.getBuildersList().add(configuration);
+		project.getBuildersList().add(configuration);
 
-        //Trigger build
-        jenkinsRule.waitUntilNoActivity();
-        jenkinsRule.buildAndAssertSuccess(project);
+		//Trigger build
+		jenkinsRule.waitUntilNoActivity();
+		jenkinsRule.buildAndAssertSuccess(project);
 
-        //Check results
-        FreeStyleBuild lastBuild2 = project.getLastBuild();
-        assertNotNull(lastBuild2);
-        List<String> log = IOUtils.readLines(lastBuild2.getLogInputStream());
-        assertTrue(log.toString(), log.toString().contains("Started by user " + (authenticate ? "test" : "anonymous") + ", Building in workspace"));
+		//Check results
+		FreeStyleBuild lastBuild2 = project.getLastBuild();
+		assertNotNull(lastBuild2);
+		List<String> log = IOUtils.readLines(lastBuild2.getLogInputStream());
+		assertTrue(log.toString(), log.toString().contains("Started by user " + (authenticate ? "test" : "anonymous") + ", Building in workspace"));
 
-        FreeStyleBuild lastBuild = remoteProject.getLastBuild();
-        assertNotNull("lastBuild null", lastBuild);
-        if (withParam){
-            EnvVars remoteEnv = lastBuild.getEnvironment(new LogTaskListener(null, null));
-        	for (Map.Entry<String, String> p : parms.entrySet()) {
-        		assertEquals(p.getValue(), remoteEnv.get(p.getKey()));
-        	}
-        } else {
-        	assertNotEquals("lastBuild should be executed no matter the result which depends on the remote job configuration.", null, lastBuild.getNumber());
-        }
-    }
+		FreeStyleBuild lastBuild = remoteProject.getLastBuild();
+		assertNotNull("lastBuild null", lastBuild);
+		if (withParam) {
+			EnvVars remoteEnv = lastBuild.getEnvironment(new LogTaskListener(null, null));
+			for (Map.Entry<String, String> p : params.entrySet()) {
+				assertEquals(p.getValue(), remoteEnv.get(p.getKey()));
+			}
+		} else {
+			assertNotEquals("lastBuild should be executed no matter the result which depends on the remote job configuration.", null, lastBuild.getNumber());
+		}
+	}
 
 	private void _testRemoteBuild(boolean authenticate) throws Exception {
 		FreeStyleProject remoteProject = jenkinsRule.createFreeStyleProject();
@@ -173,341 +173,311 @@ public class RemoteBuildConfigurationTest {
 		_testRemoteBuild(authenticate, true, remoteProject);
 	}
 
-    @Test @WithoutJenkins
-    public void testDefaults() throws IOException {
+	@Test @WithoutJenkins
+	public void testDefaults() throws IOException {
 
-      RemoteBuildConfiguration config = new RemoteBuildConfiguration();
-      config.setJob("job");
+		RemoteBuildConfiguration config = new RemoteBuildConfiguration();
+		config.setJob("job");
 
-      assertEquals(false, config.getBlockBuildUntilComplete()); //False in Job
-      assertEquals(false, config.getEnhancedLogging());
-      assertEquals("job", config.getJob());
-      assertEquals(false, config.getLoadParamsFromFile());
-      assertEquals(false, config.getOverrideAuth());
-      assertEquals("", config.getParameterFile());
-      assertEquals("", config.getParameters());
-      assertEquals(10000, config.getHttpGetReadTimeout());
-      assertEquals(30000, config.getHttpPostReadTimeout());
-      assertEquals(10, config.getPollInterval(RemoteBuildStatus.RUNNING));
-      assertEquals(false, config.getPreventRemoteBuildQueue());
-      assertEquals(null, config.getRemoteJenkinsName());
-      assertEquals(false, config.getShouldNotFailBuild());
-      assertEquals(false, config.getOverrideTrustAllCertificates());
-      assertEquals(false, config.getTrustAllCertificates());
-      assertEquals("", config.getToken());
-    }
+		assertFalse(config.getBlockBuildUntilComplete()); //False in Job
+		assertFalse(config.getEnhancedLogging());
+		assertEquals("job", config.getJob());
+		assertFalse(config.getOverrideAuth());
+		assertTrue(config.getParameters2() instanceof MapParameters);
+		assertEquals(10000, config.getHttpGetReadTimeout());
+		assertEquals(30000, config.getHttpPostReadTimeout());
+		assertEquals(10, config.getPollInterval(RemoteBuildStatus.RUNNING));
+		assertFalse(config.getPreventRemoteBuildQueue());
+		assertNull(config.getRemoteJenkinsName());
+		assertFalse(config.getShouldNotFailBuild());
+		assertFalse(config.getOverrideTrustAllCertificates());
+		assertFalse(config.getTrustAllCertificates());
+		assertEquals("", config.getToken());
+	}
 
-    @Test @WithoutJenkins
-    public void testDefaultsPipelineStep() throws IOException {
+	@Test @WithoutJenkins
+	public void testDefaultsPipelineStep() throws IOException {
 
-      RemoteBuildPipelineStep config = new RemoteBuildPipelineStep("job");
+		RemoteBuildPipelineStep config = new RemoteBuildPipelineStep("job");
 
-      assertEquals(true, config.getBlockBuildUntilComplete()); //True in Pipeline Step
-      assertEquals(false, config.getEnhancedLogging());
-      assertEquals("job", config.getJob());
-      assertEquals(false, config.getLoadParamsFromFile());
-      assertTrue(config.getAuth() instanceof NullAuth);
-      assertEquals("", config.getParameterFile());
-      assertEquals("", config.getParameters());
-      assertEquals(10000, config.getHttpGetReadTimeout());
-      assertEquals(30000, config.getHttpPostReadTimeout());
-      assertEquals(10, config.getPollInterval());
-      assertEquals(false, config.getPreventRemoteBuildQueue());
-      assertEquals(null, config.getRemoteJenkinsName());
-      assertEquals(false, config.getShouldNotFailBuild());
-      assertEquals(false, config.getOverrideTrustAllCertificates());
-      assertEquals(false, config.getTrustAllCertificates());
-      assertEquals("", config.getToken());
-    }
+		assertTrue(config.getBlockBuildUntilComplete()); //True in Pipeline Step
+		assertFalse(config.getEnhancedLogging());
+		assertEquals("job", config.getJob());
+		assertTrue(config.getAuth() instanceof NullAuth);
+		assertTrue(config.getParameters2() instanceof MapParameters);
+		assertEquals(10000, config.getHttpGetReadTimeout());
+		assertEquals(30000, config.getHttpPostReadTimeout());
+		assertEquals(10, config.getPollInterval());
+		assertFalse(config.getPreventRemoteBuildQueue());
+		assertNull(config.getRemoteJenkinsName());
+		assertFalse(config.getShouldNotFailBuild());
+		assertFalse(config.getOverrideTrustAllCertificates());
+		assertFalse(config.getTrustAllCertificates());
+		assertEquals("", config.getToken());
+	}
 
-    @Test @WithoutJenkins
-    public void testJobUrlHandling_withoutServer() throws IOException {
-        RemoteBuildConfiguration config = new RemoteBuildConfiguration();
-        config.setJob("MyJob");
-        assertEquals("MyJob", config.getJob());
-        try {
-            config.evaluateEffectiveRemoteHost(null);
-            fail("findRemoteHost() should throw an AbortException since server not specified");
-        } catch(AbortException e) {
-            assertEquals("Configuration of the remote Jenkins host is missing.", e.getMessage());
-        }
-    }
+	@Test @WithoutJenkins
+	public void testJobUrlHandling_withoutServer() throws IOException {
+		RemoteBuildConfiguration config = new RemoteBuildConfiguration();
+		config.setJob("MyJob");
+		assertEquals("MyJob", config.getJob());
+		try {
+			config.evaluateEffectiveRemoteHost(null);
+			fail("findRemoteHost() should throw an AbortException since server not specified");
+		} catch (AbortException e) {
+			assertEquals("Configuration of the remote Jenkins host is missing.", e.getMessage());
+		}
+	}
 
-    @Test @WithoutJenkins
-    public void testJobUrlHandling_withJobNameAndRemoteUrl() throws IOException {
-        RemoteBuildConfiguration config = new RemoteBuildConfiguration();
-        config.setJob("MyJob");
-        config.setRemoteJenkinsUrl("http://test:8080");
-        assertEquals("MyJob", config.getJob());
-        assertEquals("http://test:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
-    }
+	@Test @WithoutJenkins
+	public void testJobUrlHandling_withJobNameAndRemoteUrl() throws IOException {
+		RemoteBuildConfiguration config = new RemoteBuildConfiguration();
+		config.setJob("MyJob");
+		config.setRemoteJenkinsUrl("http://test:8080");
+		assertEquals("MyJob", config.getJob());
+		assertEquals("http://test:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
+	}
 
-    @Test @WithoutJenkins
-    public void testJobUrlHandling_withJobNameAndRemoteName() throws IOException {
-        RemoteBuildConfiguration config = new RemoteBuildConfiguration();
-        config.setJob("MyJob");
-        config = mockGlobalRemoteHost(config, "remoteJenkinsName", "http://test:8080");
+	@Test @WithoutJenkins
+	public void testJobUrlHandling_withJobNameAndRemoteName() throws IOException {
+		RemoteBuildConfiguration config = new RemoteBuildConfiguration();
+		config.setJob("MyJob");
+		config = mockGlobalRemoteHost(config, "remoteJenkinsName", "http://test:8080");
 
-        config.setRemoteJenkinsName("remoteJenkinsName");
-        assertEquals("MyJob", config.getJob());
-        assertEquals("http://test:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
-    }
+		config.setRemoteJenkinsName("remoteJenkinsName");
+		assertEquals("MyJob", config.getJob());
+		assertEquals("http://test:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
+	}
 
-    @Test @WithoutJenkins
-    public void testJobUrlHandling_withMultiFolderJobNameAndRemoteName() throws IOException {
-        RemoteBuildConfiguration config = new RemoteBuildConfiguration();
-        config.setJob("A/B/C/D/MyJob");
-        config = mockGlobalRemoteHost(config, "remoteJenkinsName", "http://test:8080");
+	@Test @WithoutJenkins
+	public void testJobUrlHandling_withMultiFolderJobNameAndRemoteName() throws IOException {
+		RemoteBuildConfiguration config = new RemoteBuildConfiguration();
+		config.setJob("A/B/C/D/MyJob");
+		config = mockGlobalRemoteHost(config, "remoteJenkinsName", "http://test:8080");
 
-        config.setRemoteJenkinsName("remoteJenkinsName");
-        assertEquals("A/B/C/D/MyJob", config.getJob());
-        assertEquals("http://test:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
-    }
+		config.setRemoteJenkinsName("remoteJenkinsName");
+		assertEquals("A/B/C/D/MyJob", config.getJob());
+		assertEquals("http://test:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
+	}
 
-    @Test @WithoutJenkins
-    public void testJobUrlHandling_withJobUrl() throws IOException {
-        RemoteBuildConfiguration config = new RemoteBuildConfiguration();
-        config.setJob("http://test:8080/job/folder/job/MyJob");
-        assertEquals("http://test:8080/job/folder/job/MyJob", config.getJob()); //The value configured for "job"
-        assertEquals("http://test:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
-    }
+	@Test @WithoutJenkins
+	public void testJobUrlHandling_withJobUrl() throws IOException {
+		RemoteBuildConfiguration config = new RemoteBuildConfiguration();
+		config.setJob("http://test:8080/job/folder/job/MyJob");
+		assertEquals("http://test:8080/job/folder/job/MyJob", config.getJob()); //The value configured for "job"
+		assertEquals("http://test:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
+	}
 
-    @Test @WithoutJenkins
-    public void testJobUrlHandling_withJobUrlAndRemoteUrl() throws IOException {
-        //URL specified for "job" shall override specified remote host
-        RemoteBuildConfiguration config = new RemoteBuildConfiguration();
-        config.setJob("http://testA:8080/job/folder/job/MyJobA");
-        config.setRemoteJenkinsUrl("http://testB:8080");
-        assertEquals("http://testA:8080/job/folder/job/MyJobA", config.getJob()); //The value configured for "job"
-        assertEquals("http://testA:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
-    }
+	@Test @WithoutJenkins
+	public void testJobUrlHandling_withJobUrlAndRemoteUrl() throws IOException {
+		//URL specified for "job" shall override specified remote host
+		RemoteBuildConfiguration config = new RemoteBuildConfiguration();
+		config.setJob("http://testA:8080/job/folder/job/MyJobA");
+		config.setRemoteJenkinsUrl("http://testB:8080");
+		assertEquals("http://testA:8080/job/folder/job/MyJobA", config.getJob()); //The value configured for "job"
+		assertEquals("http://testA:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
+	}
 
-    @Test @WithoutJenkins
-    public void testJobUrlHandling_withJobUrlAndRemoteName() throws IOException {
-        //URL specified for "job" shall override global setting
-        RemoteBuildConfiguration config = new RemoteBuildConfiguration();
-        config.setJob("http://testA:8080/job/folder/job/MyJobA");
-        config = mockGlobalRemoteHost(config, "remoteJenkinsName", "http://testB:8080");
+	@Test @WithoutJenkins
+	public void testJobUrlHandling_withJobUrlAndRemoteName() throws IOException {
+		//URL specified for "job" shall override global setting
+		RemoteBuildConfiguration config = new RemoteBuildConfiguration();
+		config.setJob("http://testA:8080/job/folder/job/MyJobA");
+		config = mockGlobalRemoteHost(config, "remoteJenkinsName", "http://testB:8080");
 
-        config.setRemoteJenkinsName("remoteJenkinsName");
-        assertEquals("http://testA:8080/job/folder/job/MyJobA", config.getJob()); //The value configured for "job"
-        assertEquals("http://testA:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
-    }
+		config.setRemoteJenkinsName("remoteJenkinsName");
+		assertEquals("http://testA:8080/job/folder/job/MyJobA", config.getJob()); //The value configured for "job"
+		assertEquals("http://testA:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
+	}
 
-    @Test @WithoutJenkins
-    public void testEvaluateEffectiveRemoteHost_withoutJob() throws IOException, NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
-        try {
-            RemoteBuildConfiguration config = new RemoteBuildConfiguration();
-            config.setJob("xxx");
-            Field field = config.getClass().getDeclaredField("job");
-            field.setAccessible(true);
-            field.set(config, "");
-            config.evaluateEffectiveRemoteHost(null);
-            fail("findRemoteHost() should throw an AbortException since job not specified");
-        } catch(AbortException e) {
-            assertEquals("Parameter 'Remote Job Name or URL' ('job' variable in Pipeline) not specified.", e.getMessage());
-        }
-    }
+	@Test @WithoutJenkins
+	public void testEvaluateEffectiveRemoteHost_withoutJob() throws IOException, NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+		try {
+			RemoteBuildConfiguration config = new RemoteBuildConfiguration();
+			config.setJob("xxx");
+			Field field = config.getClass().getDeclaredField("job");
+			field.setAccessible(true);
+			field.set(config, "");
+			config.evaluateEffectiveRemoteHost(null);
+			fail("findRemoteHost() should throw an AbortException since job not specified");
+		} catch (AbortException e) {
+			assertEquals("Parameter 'Remote Job Name or URL' ('job' variable in Pipeline) not specified.", e.getMessage());
+		}
+	}
 
-    @Test @WithoutJenkins
-    public void testRemoteUrlOverridesRemoteName() throws IOException {
-        RemoteBuildConfiguration config = new RemoteBuildConfiguration();
-        config.setJob("MyJob");
-        config = mockGlobalRemoteHost(config, "remoteJenkinsName", "http://globallyConfigured:8080");
+	@Test @WithoutJenkins
+	public void testRemoteUrlOverridesRemoteName() throws IOException {
+		RemoteBuildConfiguration config = new RemoteBuildConfiguration();
+		config.setJob("MyJob");
+		config = mockGlobalRemoteHost(config, "remoteJenkinsName", "http://globallyConfigured:8080");
 
-        config.setRemoteJenkinsName("remoteJenkinsName");
-        assertEquals("http://globallyConfigured:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
+		config.setRemoteJenkinsName("remoteJenkinsName");
+		assertEquals("http://globallyConfigured:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
 
-        //Now override remote host URL
-        config.setRemoteJenkinsUrl("http://locallyOverridden:8080");
-        assertEquals("MyJob", config.getJob());
-        assertEquals("http://locallyOverridden:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
-    }
+		//Now override remote host URL
+		config.setRemoteJenkinsUrl("http://locallyOverridden:8080");
+		assertEquals("MyJob", config.getJob());
+		assertEquals("http://locallyOverridden:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
+	}
 
-    /**
-     * Testing if it is possible to set the TrustAllCertificates-parameter with OverrideTrustAllCertificates set to true
-     *
-     * @throws IOException
-     */
-    @Test @WithoutJenkins
-    public void testRemoteOverridesTrustAllCertificates() throws IOException {
-        RemoteBuildConfiguration config = new RemoteBuildConfiguration();
-        config.setJob("MyJob");
-        config.setTrustAllCertificates(false);
-        config.setOverrideTrustAllCertificates(true);
+	/**
+	 * Testing if it is possible to set the TrustAllCertificates-parameter with OverrideTrustAllCertificates set to true
+	 *
+	 * @throws IOException
+	 */
+	@Test @WithoutJenkins
+	public void testRemoteOverridesTrustAllCertificates() throws IOException {
+		RemoteBuildConfiguration config = new RemoteBuildConfiguration();
+		config.setJob("MyJob");
+		config.setTrustAllCertificates(false);
+		config.setOverrideTrustAllCertificates(true);
 
-        config = mockGlobalRemoteHost(config,
-                "remoteJenkinsName",
-                "http://globallyConfigured:8080",
-                true);
+		config = mockGlobalRemoteHost(config,
+				"remoteJenkinsName",
+				"http://globallyConfigured:8080",
+				true);
 
-        config.setRemoteJenkinsName("remoteJenkinsName");
-        assertTrue(config.getTrustAllCertificates());
-    }
+		config.setRemoteJenkinsName("remoteJenkinsName");
+		assertTrue(config.getTrustAllCertificates());
+	}
 
-    @Test @WithoutJenkins
-    public void testEvaluateEffectiveRemoteHost_jobNameMissing() throws IOException {
-        RemoteBuildConfiguration config = new RemoteBuildConfiguration();
-        try {
-            config.evaluateEffectiveRemoteHost(null);
-        }
-        catch (AbortException e) {
-            assertEquals("Parameter 'Remote Job Name or URL' ('job' variable in Pipeline) not specified.", e.getMessage());
-        }
-    }
+	@Test @WithoutJenkins
+	public void testEvaluateEffectiveRemoteHost_jobNameMissing() throws IOException {
+		RemoteBuildConfiguration config = new RemoteBuildConfiguration();
+		try {
+			config.evaluateEffectiveRemoteHost(null);
+		} catch (final AbortException e) {
+			assertEquals("Parameter 'Remote Job Name or URL' ('job' variable in Pipeline) not specified.", e.getMessage());
+		}
+	}
 
-    @Test @WithoutJenkins
-    public void testEvaluateEffectiveRemoteHost_globalConfigMissing() throws IOException {
-        RemoteBuildConfiguration config = new RemoteBuildConfiguration();
-        config.setJob("MyJob");
-        config = mockGlobalRemoteHost(config, "remoteJenkinsName", "http://globallyConfigured:8080");
+	@Test @WithoutJenkins
+	public void testEvaluateEffectiveRemoteHost_globalConfigMissing() throws IOException {
+		RemoteBuildConfiguration config = new RemoteBuildConfiguration();
+		config.setJob("MyJob");
+		config = mockGlobalRemoteHost(config, "remoteJenkinsName", "http://globallyConfigured:8080");
 
-        config.setRemoteJenkinsName("notConfiguredRemoteHost");
-        try {
-            config.evaluateEffectiveRemoteHost(null);
-        }
-        catch (AbortException e) {
-            assertEquals("Could get remote host with ID 'notConfiguredRemoteHost' configured in Jenkins global configuration. Please check your global configuration.", e.getMessage());
-        }
-    }
+		config.setRemoteJenkinsName("notConfiguredRemoteHost");
+		try {
+			config.evaluateEffectiveRemoteHost(null);
+		} catch (AbortException e) {
+			assertEquals("Could get remote host with ID 'notConfiguredRemoteHost' configured in Jenkins global configuration. Please check your global configuration.", e.getMessage());
+		}
+	}
 
-    @Test @WithoutJenkins
-    public void testEvaluateEffectiveRemoteHost_globalConfigMissing_localOverrideHostURL() throws IOException {
-        RemoteBuildConfiguration config = new RemoteBuildConfiguration();
-        config.setJob("MyJob");
-        config = mockGlobalRemoteHost(config, "remoteJenkinsName", "http://globallyConfigured:8080");
+	@Test @WithoutJenkins
+	public void testEvaluateEffectiveRemoteHost_globalConfigMissing_localOverrideHostURL() throws IOException {
+		RemoteBuildConfiguration config = new RemoteBuildConfiguration();
+		config.setJob("MyJob");
+		config = mockGlobalRemoteHost(config, "remoteJenkinsName", "http://globallyConfigured:8080");
 
-        config.setRemoteJenkinsName("notConfiguredRemoteHost");
-        config.setRemoteJenkinsUrl("http://locallyOverridden:8080");
-        assertEquals("http://locallyOverridden:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
-    }
+		config.setRemoteJenkinsName("notConfiguredRemoteHost");
+		config.setRemoteJenkinsUrl("http://locallyOverridden:8080");
+		assertEquals("http://locallyOverridden:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
+	}
 
-    @Test @WithoutJenkins
-    public void testEvaluateEffectiveRemoteHost_globalConfigMissing_localOverrideJobURL() throws IOException {
-        RemoteBuildConfiguration config = new RemoteBuildConfiguration();
-        config.setJob("http://localJobUrl:8080/job/MyJob");
-        config = mockGlobalRemoteHost(config, "remoteJenkinsName", "http://globallyConfigured:8080");
+	@Test @WithoutJenkins
+	public void testEvaluateEffectiveRemoteHost_globalConfigMissing_localOverrideJobURL() throws IOException {
+		RemoteBuildConfiguration config = new RemoteBuildConfiguration();
+		config.setJob("http://localJobUrl:8080/job/MyJob");
+		config = mockGlobalRemoteHost(config, "remoteJenkinsName", "http://globallyConfigured:8080");
 
-        config.setRemoteJenkinsName("notConfiguredRemoteHost");
-        assertEquals("http://localJobUrl:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
-    }
+		config.setRemoteJenkinsName("notConfiguredRemoteHost");
+		assertEquals("http://localJobUrl:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
+	}
 
-    @Test @WithoutJenkins
-    public void testEvaluateEffectiveRemoteHost_localOverrideHostURL() throws IOException {
-        RemoteBuildConfiguration config = new RemoteBuildConfiguration();
-        config.setJob("MyJob");
-        config.setRemoteJenkinsUrl("http://hostname:8080");
-        assertEquals("http://hostname:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
-    }
+	@Test @WithoutJenkins
+	public void testEvaluateEffectiveRemoteHost_localOverrideHostURL() throws IOException {
+		RemoteBuildConfiguration config = new RemoteBuildConfiguration();
+		config.setJob("MyJob");
+		config.setRemoteJenkinsUrl("http://hostname:8080");
+		assertEquals("http://hostname:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
+	}
 
-    @Test @WithoutJenkins
-    public void testEvaluateEffectiveRemoteHost_localOverrideHostURLWrong() throws IOException {
-        RemoteBuildConfiguration config = new RemoteBuildConfiguration();
-        config.setJob("MyJob");
-        config.setRemoteJenkinsUrl("hostname:8080");
-        try {
-            config.evaluateEffectiveRemoteHost(null);
-            fail("Expected AbortException");
-        }
-        catch (AbortException e) {
-            assertEquals("The 'Override remote host URL' parameter value (remoteJenkinsUrl: 'hostname:8080') is no valid URL", e.getMessage());
-        }
-    }
+	@Test @WithoutJenkins
+	public void testEvaluateEffectiveRemoteHost_localOverrideHostURLWrong() throws IOException {
+		RemoteBuildConfiguration config = new RemoteBuildConfiguration();
+		config.setJob("MyJob");
+		config.setRemoteJenkinsUrl("hostname:8080");
+		try {
+			config.evaluateEffectiveRemoteHost(null);
+			fail("Expected AbortException");
+		} catch (AbortException e) {
+			assertEquals("The 'Override remote host URL' parameter value (remoteJenkinsUrl: 'hostname:8080') is no valid URL", e.getMessage());
+		}
+	}
 
-    private RemoteBuildConfiguration mockGlobalRemoteHost(RemoteBuildConfiguration config, String remoteName, String remoteUrl) throws MalformedURLException {
-        RemoteJenkinsServer jenkinsServer = new RemoteJenkinsServer();
-        jenkinsServer.setDisplayName(remoteName);
-        jenkinsServer.setAddress(remoteUrl);
+	private RemoteBuildConfiguration mockGlobalRemoteHost(RemoteBuildConfiguration config, String remoteName, String remoteUrl) throws MalformedURLException {
+		RemoteJenkinsServer jenkinsServer = new RemoteJenkinsServer();
+		jenkinsServer.setDisplayName(remoteName);
+		jenkinsServer.setAddress(remoteUrl);
 
-        RemoteBuildConfiguration spy = spy(config);
-        DescriptorImpl descriptor = DescriptorImpl.newInstanceForTests();
-        descriptor.setRemoteSites(jenkinsServer);
-        doReturn(descriptor).when(spy).getDescriptor();
+		RemoteBuildConfiguration spy = spy(config);
+		DescriptorImpl descriptor = DescriptorImpl.newInstanceForTests();
+		descriptor.setRemoteSites(jenkinsServer);
+		doReturn(descriptor).when(spy).getDescriptor();
 
-        return spy;
-    }
+		return spy;
+	}
 
-    private RemoteBuildConfiguration mockGlobalRemoteHost(
-            RemoteBuildConfiguration config, String remoteName, String remoteUrl, boolean trustAllCertificates
-    ) throws MalformedURLException {
-        RemoteJenkinsServer jenkinsServer = new RemoteJenkinsServer();
-        jenkinsServer.setDisplayName(remoteName);
-        jenkinsServer.setAddress(remoteUrl);
+	private RemoteBuildConfiguration mockGlobalRemoteHost(
+			RemoteBuildConfiguration config, String remoteName, String remoteUrl, boolean trustAllCertificates
+	) throws MalformedURLException {
+		RemoteJenkinsServer jenkinsServer = new RemoteJenkinsServer();
+		jenkinsServer.setDisplayName(remoteName);
+		jenkinsServer.setAddress(remoteUrl);
 
-        RemoteBuildConfiguration spy = spy(config);
-        DescriptorImpl descriptor = DescriptorImpl.newInstanceForTests();
-        descriptor.setRemoteSites(jenkinsServer);
-        doReturn(descriptor).when(spy).getDescriptor();
-        spy.setTrustAllCertificates(trustAllCertificates);
+		RemoteBuildConfiguration spy = spy(config);
+		DescriptorImpl descriptor = DescriptorImpl.newInstanceForTests();
+		descriptor.setRemoteSites(jenkinsServer);
+		doReturn(descriptor).when(spy).getDescriptor();
+		spy.setTrustAllCertificates(trustAllCertificates);
 
-        return spy;
-    }
+		return spy;
+	}
 
-    @Test @WithoutJenkins
-    public void testRemoveTrailingSlashes() {
-        assertEquals("xxx", RemoteBuildConfiguration.removeTrailingSlashes("xxx"));
-        assertEquals("xxx", RemoteBuildConfiguration.removeTrailingSlashes("xxx/"));
-        assertEquals("xxx", RemoteBuildConfiguration.removeTrailingSlashes("xxx//////"));
-        assertEquals("xxx/yy", RemoteBuildConfiguration.removeTrailingSlashes("xxx/yy//"));
-        assertEquals("xxx", RemoteBuildConfiguration.removeTrailingSlashes("xxx/     "));
-    }
+	@Test @WithoutJenkins
+	public void testGenerateEffectiveRemoteBuildURL() throws Exception {
+		URL remoteBuildURL = new URL("http://test:8080/job/Abc/3/");
 
-    @Test @WithoutJenkins
-    public void testRemoveQueryParameters() {
-        assertEquals("xxx", RemoteBuildConfiguration.removeQueryParameters("xxx"));
-        assertEquals("http://test:8080/MyJob", RemoteBuildConfiguration.removeQueryParameters("http://test:8080/MyJob?xy=abc"));
-        assertEquals("xxx", RemoteBuildConfiguration.removeQueryParameters("xxx?zzz"));
-    }
+		assertEquals(new URL("https://foobar:8443/job/Abc/3/"), RemoteBuildConfiguration.generateEffectiveRemoteBuildURL(remoteBuildURL, "https://foobar:8443"));
+		assertEquals(new URL("http://foobar:8888/job/Abc/3/"), RemoteBuildConfiguration.generateEffectiveRemoteBuildURL(remoteBuildURL, "http://foobar:8888"));
+		assertEquals(new URL("https://foobar/job/Abc/3/"), RemoteBuildConfiguration.generateEffectiveRemoteBuildURL(remoteBuildURL, "https://foobar"));
+		assertEquals(new URL("http://foobar/job/Abc/3/"), RemoteBuildConfiguration.generateEffectiveRemoteBuildURL(remoteBuildURL, "http://foobar"));
+	}
 
-    @Test @WithoutJenkins
-    public void testRemoveHashParameters() {
-        assertEquals("xxx", RemoteBuildConfiguration.removeHashParameters("xxx"));
-        assertEquals("http://test:8080/MyJob", RemoteBuildConfiguration.removeHashParameters("http://test:8080/MyJob#asdsad"));
-        assertEquals("xxx", RemoteBuildConfiguration.removeHashParameters("xxx#zzz"));
-    }
+	@Test @WithoutJenkins
+	public void testGenerateJobUrl() throws MalformedURLException, AbortException {
+		RemoteJenkinsServer remoteServer = new RemoteJenkinsServer();
+		remoteServer.setAddress("https://server:8080/jenkins");
 
-    @Test @WithoutJenkins
-    public void testGenerateEffectiveRemoteBuildURL() throws Exception {
-        URL remoteBuildURL = new URL("http://test:8080/job/Abc/3/");
+		assertEquals("https://server:8080/jenkins/job/JobName", RemoteBuildConfiguration.generateJobUrl(remoteServer, "JobName"));
+		assertEquals("https://server:8080/jenkins/job/Folder/job/JobName", RemoteBuildConfiguration.generateJobUrl(remoteServer, "Folder/JobName"));
+		assertEquals("https://server:8080/jenkins/job/More/job/than/job/one/job/folder", RemoteBuildConfiguration.generateJobUrl(remoteServer, "More/than/one/folder"));
+		try {
+			RemoteBuildConfiguration.generateJobUrl(remoteServer, "");
+			Assert.fail("Expected IllegalArgumentException");
+		} catch (IllegalArgumentException e) { }
+		try {
+			RemoteBuildConfiguration.generateJobUrl(remoteServer, null);
+			Assert.fail("Expected IllegalArgumentException");
+		} catch (IllegalArgumentException e) { }
+		try {
+			RemoteBuildConfiguration.generateJobUrl(null, "JobName");
+			Assert.fail("Expected NullPointerException");
+		} catch (NullPointerException e) { }
 
-        assertEquals(new URL("https://foobar:8443/job/Abc/3/"), RemoteBuildConfiguration.generateEffectiveRemoteBuildURL(remoteBuildURL, "https://foobar:8443"));
-        assertEquals(new URL("http://foobar:8888/job/Abc/3/"), RemoteBuildConfiguration.generateEffectiveRemoteBuildURL(remoteBuildURL, "http://foobar:8888"));
-        assertEquals(new URL("https://foobar/job/Abc/3/"), RemoteBuildConfiguration.generateEffectiveRemoteBuildURL(remoteBuildURL, "https://foobar"));
-        assertEquals(new URL("http://foobar/job/Abc/3/"), RemoteBuildConfiguration.generateEffectiveRemoteBuildURL(remoteBuildURL, "http://foobar"));
-    }
+		//Test trailing slash
+		remoteServer.setAddress("https://server:8080/jenkins/");
+		assertEquals("https://server:8080/jenkins/job/JobName", RemoteBuildConfiguration.generateJobUrl(remoteServer, "JobName"));
 
-    @Test @WithoutJenkins
-    public void testGenerateJobUrl() throws MalformedURLException, AbortException {
-        RemoteJenkinsServer remoteServer = new RemoteJenkinsServer();
-        remoteServer.setAddress("https://server:8080/jenkins");
+		try {
+			RemoteJenkinsServer missingUrl = new RemoteJenkinsServer();
+			RemoteBuildConfiguration.generateJobUrl(missingUrl, "JobName");
+			Assert.fail("Expected AbortException");
+		} catch (AbortException e) { }
 
-        assertEquals("https://server:8080/jenkins/job/JobName", RemoteBuildConfiguration.generateJobUrl(remoteServer, "JobName"));
-        assertEquals("https://server:8080/jenkins/job/Folder/job/JobName", RemoteBuildConfiguration.generateJobUrl(remoteServer, "Folder/JobName"));
-        assertEquals("https://server:8080/jenkins/job/More/job/than/job/one/job/folder", RemoteBuildConfiguration.generateJobUrl(remoteServer, "More/than/one/folder"));
-        try {
-            RemoteBuildConfiguration.generateJobUrl(remoteServer, "");
-            Assert.fail("Expected IllegalArgumentException");
-        } catch(IllegalArgumentException e) {}
-        try {
-            RemoteBuildConfiguration.generateJobUrl(remoteServer, null);
-            Assert.fail("Expected IllegalArgumentException");
-        } catch(IllegalArgumentException e) {}
-        try {
-            RemoteBuildConfiguration.generateJobUrl(null, "JobName");
-            Assert.fail("Expected NullPointerException");
-        } catch(NullPointerException e) {}
-
-        //Test trailing slash
-        remoteServer.setAddress("https://server:8080/jenkins/");
-        assertEquals("https://server:8080/jenkins/job/JobName", RemoteBuildConfiguration.generateJobUrl(remoteServer, "JobName"));
-
-        try {
-            RemoteJenkinsServer missingUrl = new RemoteJenkinsServer();
-            RemoteBuildConfiguration.generateJobUrl(missingUrl, "JobName");
-            Assert.fail("Expected AbortException");
-        } catch(AbortException e) {}
-
-    }
+	}
 
 	@Test
 	public void testRemoteFolderedBuild() throws Exception {
@@ -538,10 +508,10 @@ public class RemoteBuildConfigurationTest {
 		remoteProject.addProperty(
 				new ParametersDefinitionProperty(new StringParameterDefinition("parameterName1", "default1"),
 						new StringParameterDefinition("parameterName2", "default2")));
-		Map<String, String> parms = new HashMap<>();
-		parms.put("parameterName1", TestConst.garbled5KString1);
-		parms.put("parameterName2", TestConst.garbled5KString2);
-		_testRemoteBuild(true, true, remoteProject, parms);
+		Map<String, String> params = new HashMap<>();
+		params.put("parameterName1", TestConst.garbled5KString1);
+		params.put("parameterName2", TestConst.garbled5KString2);
+		this._testRemoteBuild(true, true, remoteProject, params);
 	}
 
 	@Test
@@ -557,7 +527,6 @@ public class RemoteBuildConfigurationTest {
 
 	@Test @WithoutJenkins
 	public void testParseStringParameters() {
-		RemoteBuildConfiguration config = new RemoteBuildConfiguration();
 		final String parameters = join("\n", asList(
 				"# bla bla",       // Comment
 				"",                // Empty line
@@ -568,22 +537,12 @@ public class RemoteBuildConfigurationTest {
 				"line2",           // Multi-line parameter
 				"line3"            // Multi-line parameter
 		));
-		config.setParameters(parameters);
+		final Map<String, String> actualParametersMap = JobParameters.parseStringParameters(parameters);
 
 		final Map<String, String> expectedParametersMap = new HashMap<>();
 		expectedParametersMap.put("PARAM1", "toto");
 		expectedParametersMap.put("PARAM2", "dG90bwo="); // This one should fail because it's broken (see issue 58818)
 		expectedParametersMap.put("PARAM3", "line1"); // We keep the wrong value in the test because it's unfixable with string parameters
-
-		final List<String> actualParameterList = config.getCleanedParameters(
-				config.getParameterList(null)
-		);
-		final Map<String, String> actualParametersMap = actualParameterList.stream()
-				.map(line -> {
-					final String[] splitLine = line.split("=");
-					return new AbstractMap.SimpleEntry<>(splitLine[0], splitLine.length > 1 ? splitLine[1] : "");
-				})
-				.collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
 
 		assertEquals(expectedParametersMap, actualParametersMap);
 	}


### PR DESCRIPTION
# What is this PR?

This PR is an attempt to fix the current bugs with remote job parameters. It is linked to the JIRA issues [JENKINS-68737](https://issues.jenkins.io/browse/JENKINS-68737) and [JENKINS-58818](https://issues.jenkins.io/browse/JENKINS-58818).

Currently, the parameters are read from a single string and the following example:

```
MULTI_LINE=line1
line2
line3
```

actually creates the parameters `MULTI_LINE: 'line1'`, `line2: ''` & `line3: ''` which shows three parsing issues.

## Issues

### Issue 1

The splitting of the name/value is broken and cuts the `=` characters from the value (see [the JIRA issue](https://issues.jenkins.io/browse/JENKINS-58818))

### Issue 2

The multi-line parameter's value is cut just after the first line.

### Issue 3

The lines 2+ of the multi-line parameter are seen as variable names.

## How does this PR try to solve the problem

The issue can be fixed by having one field for the name and another for the value.

What I did is update the job configuration so that instead of accepting either a big string or the path to a file containing a big string it can accept a map of parameters.

If a map is provided, there is no parsing done at all and it fixes both issues.

## What it looks like

In the UI, I added a selector for three parameters input modes:

* String parameters: the current string mode
* File parameters: the current file mode
* Map parameters: the new mode

> BONUS: I fixed the issues 1 & 3 in the big string parsing (used by `String parameters` & `File parameters` modes) since it was easy to do. The issue 2 can't be fixed that way though.

See screenshots:

_File parameters mode_

![Selection_001](https://user-images.githubusercontent.com/5594303/171911361-2b812cb4-9f46-48bd-bbd0-1d03038e2533.png)

_String parameters mode_

![Selection_002](https://user-images.githubusercontent.com/5594303/171911655-dbeb333a-d46e-49a0-a157-375e4c7067fd.png)

_Map parameters_

![Selection_003](https://user-images.githubusercontent.com/5594303/171911672-ee6980a8-11b4-49c7-ab79-ad52e4dd29a1.png)

## Migration

To avoid a plugin upgrade breaking the current configuration out there in the wild, I plugged a migration mechanism that gracefully reads old configurations and maps them to the `String parameters` or `File parameters` in the new configuration format.

> :warning: The parsing having being fixed for the issues 1 & 3, migrating old buggy configurations will actually result in some changes but I believe the worst it can do is fix broken builds, not the other way around. That's an attention point though.

## Questions that remain

I'm not sure whether having the currently implemented modes are the way to go.

I can envision an alternative solution where there are only two modes:

* `Map parameters`: the currently described solution
* `File parameters`: an update on the current solution that would accept a JSON/YAML file instead of a big string to make sure we can fix both issues

I didn't implement this that way because I could not see a clear migration path for old configuration using a file.

Maybe there should be four modes, the two legacy ones and two new modes with the map and JSON/YAML files?

## Remaining work to polish this PR

* [ ] write HTML documentation files
* [ ] test the migrations thoroughly

I'm still getting this out now because I prefer to get feedback as early as possible.

> Note: I tried to limit the noise in the PR but I had to fight my IDE's formatter for that and ended up keeping a few hard-to-remove useless diffs because I was wasting too much time. This PR is best reviewed with the `ignore whitespace` setting `ON`.