### PR TITLE
fetch remaining log after remote job finishes

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -710,6 +710,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 				handle.setBuildInfo(buildInfo);
 			}
 			if (this.getEnhancedLogging()) {
+				consoleOffset = printOffsetConsoleOutput(context, consoleOffset, buildInfo);
 				context.logger
 						.println("--------------------------------------------------------------------------------");
 			}


### PR DESCRIPTION
This PR fixes an issue, when enhancedLogging is set and remote log is trimmed. It adds a last poll for logs after the remote build finished.