### PR TITLE
Update parent POM, update dependencies, test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,11 @@
-// Builds a module using https://github.com/jenkins-infra/pipeline-library
-// Requirements:
-//   - agents with label 'linux' and 'windows'
-//   - tools with label 'jdk8' and 'mvn'
-//   - latest Pipeline plugins, 'Timestamper' plugin
-//   - recommended to use this Jenkinsfile with 'Multibranch Pipeline' plugin
-
-buildPlugin()
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+  forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -114,8 +114,14 @@
 		<dependency>
 			<groupId>org.mock-server</groupId>
 			<artifactId>mockserver-junit-rule</artifactId>
-			<version>5.14.0</version>
+			<version>5.15.0</version>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>javax.servlet</groupId>
+					<artifactId>javax.servlet-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,6 @@
 
   <properties>
     <jenkins.version>2.361.4</jenkins.version>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
     <!-- https://wiki.jenkins-ci.org/display/JENKINS/Marking+a+new+plugin+version+as+incompatible+with+older+versions -->
     <hpi.compatibleSinceVersion>3.1.6</hpi.compatibleSinceVersion>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,8 @@
 		<dependencies>
 			<dependency>
 				<groupId>io.jenkins.tools.bom</groupId>
-				<artifactId>bom-2.346.x</artifactId>
-				<version>1742.vb_70478c1b_25f</version>
+				<artifactId>bom-2.361.x</artifactId>
+				<version>2102.v854b_fec19c92</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>4.50</version>
+		<version>4.74</version>
 		<relativePath />
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,15 @@
 	</parent>
 
   <properties>
+    <revision>3.2.1</revision>
+    <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.361.4</jenkins.version>
     <!-- https://wiki.jenkins-ci.org/display/JENKINS/Marking+a+new+plugin+version+as+incompatible+with+older+versions -->
     <hpi.compatibleSinceVersion>3.1.6</hpi.compatibleSinceVersion>
   </properties>
 
 	<artifactId>Parameterized-Remote-Trigger</artifactId>
-	<version>3.2.1-SNAPSHOT</version>
+	<version>${revision}${changelist}</version>
 	<packaging>hpi</packaging>
 	<name>Parameterized Remote Trigger Plugin</name>
 	<description>This plugin gives you the ability to trigger parameterized builds on a remote Jenkins server as part of your build.</description>
@@ -49,10 +51,10 @@
 	</build>
 
 	<scm>
-		<connection>scm:git:https://github.com/jenkinsci/parameterized-remote-trigger-tlugin.git</connection>
-		<developerConnection>scm:git:git@github.com:jenkinsci/parameterized-remote-trigger-plugin.git</developerConnection>
-		<url>https://github.com/jenkinsci/parameterized-remote-trigger-plugin</url>
-		<tag>HEAD</tag>
+		<connection>scm:git:https://github.com/jenkinsci/${gitHubRepo}.git</connection>
+		<developerConnection>scm:git:git@github.com:jenkinsci/${gitHubRepo}.git</developerConnection>
+		<url>https://github.com/jenkinsci/${gitHubRepo}</url>
+		<tag>${scmTag}</tag>
 	</scm>
 
 	<repositories>
@@ -108,7 +110,6 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>5.6.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>2.18.3</version>
+			<version>5.6.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 	</build>
 
 	<scm>
-		<connection>scm:git:git://github.com/jenkinsci/parameterized-remote-trigger-tlugin.git</connection>
+		<connection>scm:git:https://github.com/jenkinsci/parameterized-remote-trigger-tlugin.git</connection>
 		<developerConnection>scm:git:git@github.com:jenkinsci/parameterized-remote-trigger-plugin.git</developerConnection>
 		<url>https://github.com/jenkinsci/parameterized-remote-trigger-plugin</url>
 		<tag>HEAD</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 
   <properties>
-    <jenkins.version>2.346.3</jenkins.version>
+    <jenkins.version>2.361.4</jenkins.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
     <!-- https://wiki.jenkins-ci.org/display/JENKINS/Marking+a+new+plugin+version+as+incompatible+with+older+versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
 			<groupId>io.jenkins.plugins</groupId>
 			<artifactId>opentelemetry</artifactId>
 			<optional>true</optional>
-			<version>2.10.0</version>
+			<version>2.17.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/utils/OtelUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/utils/OtelUtils.java
@@ -9,7 +9,7 @@ import io.opentelemetry.context.Context;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jetbrains.annotations.NotNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.util.Optional;
 
@@ -52,13 +52,13 @@ public class OtelUtils {
 				.orElseGet(OtelUtils::noop);
 	}
 
-	@NotNull
+	@NonNull
 	public static AutoCloseable noop() {
 		return () -> {
 		};
 	}
 
-	@NotNull
+	@NonNull
 	public static boolean isOpenTelemetryAvailable() {
 		return Optional.ofNullable(Jenkins.get().getPlugin("opentelemetry"))
 				.map(Plugin::getWrapper)
@@ -66,7 +66,7 @@ public class OtelUtils {
 				.orElse(false);
 	}
 
-	@NotNull
+	@NonNull
 	private static String genTraceParent(Span span) {
 		return TRACE_PARENT_VERSION + "-" + span.getSpanContext().getTraceId() + "-" + span.getSpanContext().getSpanId() + "-" + TRACE_PARENT_TRACE_FLAG;
 	}

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/OpenTelemeterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/OpenTelemeterTest.java
@@ -7,7 +7,7 @@ import hudson.security.AuthorizationStrategy;
 import hudson.security.SecurityRealm;
 import io.jenkins.plugins.opentelemetry.OpenTelemetryConfiguration;
 import io.jenkins.plugins.opentelemetry.OpenTelemetrySdkProvider;
-import org.jetbrains.annotations.NotNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -55,7 +55,7 @@ public class OpenTelemeterTest {
         mockServerClient.verify(allExpectation);
     }
 
-    @NotNull
+    @NonNull
     private FreeStyleProject createProjectTriggerFrom() throws IOException {
         FreeStyleProject project = jenkinsRule.createFreeStyleProject();
         RemoteBuildConfiguration configuration = new RemoteBuildConfiguration();
@@ -73,7 +73,7 @@ public class OpenTelemeterTest {
         return project;
     }
 
-    @NotNull
+    @NonNull
     private String[] setupRemoteJenkinsMock() {
         Expectation[] metaExp = mockServerClient.when(
                 request()
@@ -166,7 +166,7 @@ public class OpenTelemeterTest {
         return allExp;
     }
 
-    @NotNull
+    @NonNull
     private String createJobUrl() {
         return "http://localhost:" + mockServerClient.getPort() + "/job/remote1";
     }


### PR DESCRIPTION
Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 in early October and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only two Java configurations, Java 17 and Java 21 because we believe that the risk of a regression that only affects Java 11 is shallow. We generate Java 11 byte code with the Java 17 and the Java 21 builds, so we're already testing Java 11 byte code.

Testing done
===

Confirmed tests pass with Java 21 on Linux.

Supersedes pull request: #86.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue