### PR TITLE
Replace JSR-305 annotations with spotbugs annotations

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BasicBuildContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BasicBuildContext.java
@@ -1,8 +1,7 @@
 package org.jenkinsci.plugins.ParameterizedRemoteTrigger;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNullableByDefault;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import hudson.FilePath;
 import hudson.model.Run;
@@ -14,7 +13,6 @@ import hudson.model.TaskListener;
  * <br>
  * The reason for wrapping is simplicity.
  */
-@ParametersAreNullableByDefault
 public class BasicBuildContext
 {
     @Nullable @CheckForNull

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BuildContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/BuildContext.java
@@ -4,9 +4,8 @@ import static org.apache.commons.lang.StringUtils.trimToNull;
 
 import java.io.PrintStream;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNullableByDefault;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.pipeline.Handle;
 
@@ -23,39 +22,38 @@ import hudson.model.TaskListener;
  * want to provide a {@link PrintStream} for logging. Therefore the first three objects can be null, the {@link PrintStream}
  * must not be null.
  */
-@ParametersAreNullableByDefault
 public class BuildContext extends BasicBuildContext
 {
-    @Nonnull
+    @NonNull
     public final PrintStream logger;
 
-    @Nonnull
+    @NonNull
     public RemoteJenkinsServer effectiveRemoteServer;
 
     /**
      * The current Item (job, pipeline,...) where the plugin is used from.
      */
-    @Nonnull
+    @NonNull
     public final String currentItem;
 
 
-    public BuildContext(@Nullable Run<?, ?> run, @Nullable FilePath workspace, @Nullable TaskListener listener, @Nonnull PrintStream logger, @Nonnull RemoteJenkinsServer effectiveRemoteServer, @Nullable String currentItem) {
+    public BuildContext(@Nullable Run<?, ?> run, @Nullable FilePath workspace, @Nullable TaskListener listener, @NonNull PrintStream logger, @NonNull RemoteJenkinsServer effectiveRemoteServer, @Nullable String currentItem) {
         super(run, workspace, listener);
         this.logger = logger;
         this.effectiveRemoteServer = effectiveRemoteServer;
         this.currentItem = getCurrentItem(run, currentItem);
     }
 
-    public BuildContext(@Nullable Run<?, ?> run, @Nullable FilePath workspace, @Nullable TaskListener listener, @Nonnull PrintStream logger, @Nonnull RemoteJenkinsServer effectiveRemoteServer) {
+    public BuildContext(@Nullable Run<?, ?> run, @Nullable FilePath workspace, @Nullable TaskListener listener, @NonNull PrintStream logger, @NonNull RemoteJenkinsServer effectiveRemoteServer) {
         this(run, workspace, listener, logger, effectiveRemoteServer, null);
     }
 
-    public BuildContext(@Nonnull PrintStream logger, @Nonnull RemoteJenkinsServer effectiveRemoteServer, @Nullable String currentItem)
+    public BuildContext(@NonNull PrintStream logger, @NonNull RemoteJenkinsServer effectiveRemoteServer, @Nullable String currentItem)
     {
         this(null, null, null, logger, effectiveRemoteServer, currentItem);
     }
 
-    @Nonnull
+    @NonNull
     private String getCurrentItem(Run<?, ?> run, String currentItem)
     {
         String runItem = null;

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/ConnectionResponse.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/ConnectionResponse.java
@@ -1,10 +1,11 @@
 package org.jenkinsci.plugins.ParameterizedRemoteTrigger;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import net.sf.json.JSONObject;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -16,7 +17,7 @@ import java.util.stream.Collectors;
  */
 public class ConnectionResponse
 {
-    @Nonnull
+    @NonNull
     private final Map<String,List<String>> header = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
     @Nullable @CheckForNull
@@ -25,11 +26,11 @@ public class ConnectionResponse
     @Nullable @CheckForNull
     private final String rawBody;
 
-    @Nonnull
+    @NonNull
     private final int responseCode;
 
 
-    public ConnectionResponse(@Nonnull Map<String, List<String>> header, @Nullable JSONObject body, @Nonnull int responseCode)
+    public ConnectionResponse(@NonNull Map<String, List<String>> header, @Nullable JSONObject body, @NonNull int responseCode)
     {
         loadHeader(header);
         this.body = body;
@@ -37,7 +38,7 @@ public class ConnectionResponse
         this.responseCode = responseCode;
     }
 
-    public ConnectionResponse(@Nonnull Map<String, List<String>> header, @Nullable String rawBody, @Nonnull int responseCode)
+    public ConnectionResponse(@NonNull Map<String, List<String>> header, @Nullable String rawBody, @NonNull int responseCode)
     {
         loadHeader(header);
         this.body = null;
@@ -45,7 +46,7 @@ public class ConnectionResponse
         this.responseCode = responseCode;
     }
 
-    public ConnectionResponse(@Nonnull Map<String, List<String>> header, @Nonnull int responseCode)
+    public ConnectionResponse(@NonNull Map<String, List<String>> header, @NonNull int responseCode)
     {
         loadHeader(header);
         this.body = null;

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -10,10 +10,8 @@ import static org.jenkinsci.plugins.ParameterizedRemoteTrigger.utils.StringTools
 import edu.umd.cs.findbugs.annotations.NonNull;
 import net.sf.json.JSONObject;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNullableByDefault;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.Serializable;
@@ -80,7 +78,6 @@ import jenkins.tasks.SimpleBuildStep;
 /**
  * @author Maurice W.
  */
-@ParametersAreNullableByDefault
 public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep, Serializable {
 
 	private static final long serialVersionUID = -4059001060991775146L;
@@ -335,7 +332,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 	 * @throws MalformedURLException if <code>remoteJenkinsName</code> no valid URL
 	 *                               or <code>job</code> an URL but nor valid.
 	 */
-	@Nonnull
+	@NonNull
 	public RemoteJenkinsServer evaluateEffectiveRemoteHost(BasicBuildContext context) throws IOException {
 		RemoteJenkinsServer globallyConfiguredServer = findRemoteHost(this.remoteJenkinsName);
 		RemoteJenkinsServer server = globallyConfiguredServer;
@@ -752,8 +749,8 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 	 * @throws InterruptedException if any thread has interrupted the current
 	 *                              thread.
 	 */
-	@Nonnull
-	private QueueItemData getQueueItemData(@Nonnull String queueId, @Nonnull BuildContext context)
+	@NonNull
+	private QueueItemData getQueueItemData(@NonNull String queueId, @NonNull BuildContext context)
 			throws IOException, InterruptedException {
 
 		if (context.effectiveRemoteServer.getAddress() == null) {
@@ -788,8 +785,8 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 		return queueItem;
 	}
 
-	@Nonnull
-	public RemoteBuildInfo updateBuildInfo(@Nonnull RemoteBuildInfo buildInfo, @Nonnull BuildContext context)
+	@NonNull
+	public RemoteBuildInfo updateBuildInfo(@NonNull RemoteBuildInfo buildInfo, @NonNull BuildContext context)
 			throws IOException, InterruptedException {
 
 		if (buildInfo.isNotTriggered())
@@ -905,7 +902,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 		}
 	}
 
-	private void logConfiguration(@Nonnull BuildContext context, Map<String, String> effectiveParams) throws IOException {
+	private void logConfiguration(@NonNull BuildContext context, Map<String, String> effectiveParams) throws IOException {
 		String _job = getJob();
 		String _jobExpanded = getJobExpanded(context);
 		String _jobExpandedLogEntry = (_job.equals(_jobExpanded)) ? "" : "(" + _jobExpanded + ")";
@@ -1048,7 +1045,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 		return disabled;
 	}
 
-	private @Nonnull JSONObject getRemoteJobMetadata(String jobNameOrUrl, @NonNull BuildContext context)
+	private @NonNull JSONObject getRemoteJobMetadata(String jobNameOrUrl, @NonNull BuildContext context)
 			throws IOException, InterruptedException {
 
 		String remoteJobUrl = generateJobUrl(context.effectiveRemoteServer, jobNameOrUrl);
@@ -1271,7 +1268,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 		}
 
 		@Restricted(NoExternalUse.class)
-		@Nonnull
+		@NonNull
 		public ListBoxModel doFillRemoteJenkinsNameItems() {
 			ListBoxModel model = new ListBoxModel();
 

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
@@ -10,7 +10,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.List;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.Auth2;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.Auth2.Auth2Descriptor;

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/FileParameters.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/FileParameters.java
@@ -3,8 +3,9 @@ package org.jenkinsci.plugins.ParameterizedRemoteTrigger.parameters2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.joining;
 
-import javax.annotation.Nonnull;
 import java.io.BufferedReader;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Map;
@@ -92,7 +93,7 @@ public class FileParameters extends JobParameters {
 
 	@Symbol("FileParameters")
 	public static class FileParametersDescriptor extends ParametersDescriptor {
-		@Nonnull
+		@NonNull
 		@Override
 		public String getDisplayName() {
 			return "File parameters";

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/MapParameter.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/MapParameter.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.ParameterizedRemoteTrigger.parameters2;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -60,7 +61,7 @@ public class MapParameter extends AbstractDescribableImpl<MapParameter> implemen
 
 	@Symbol("MapParameter")
 	public static class MapParameterDescriptor extends Descriptor<MapParameter> {
-		@Nonnull
+		@NonNull
 		@Override
 		public String getDisplayName() {
 			return "Map parameter";

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/MapParameters.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/MapParameters.java
@@ -4,7 +4,6 @@ import static java.util.stream.Collectors.toMap;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -75,7 +74,7 @@ public class MapParameters extends JobParameters {
 
 	@Symbol("MapParameters")
 	public static class MapParametersDescriptor extends ParametersDescriptor {
-		@Nonnull
+		@NonNull
 		@Override
 		public String getDisplayName() {
 			return "Map parameters";

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/StringParameters.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/parameters2/StringParameters.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.ParameterizedRemoteTrigger.parameters2;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import java.util.Map;
 import java.util.Objects;
 
@@ -55,7 +56,7 @@ public class StringParameters extends JobParameters {
 
 	@Symbol("StringParameters")
 	public static class StringParametersDescriptor extends ParametersDescriptor {
-		@Nonnull
+		@NonNull
 		@Override
 		public String getDisplayName() {
 			return "String parameters";

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/Handle.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/Handle.java
@@ -4,16 +4,16 @@ import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.apache.commons.lang.StringUtils.trimToNull;
 
 import java.io.IOException;
+
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.util.Optional;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNullableByDefault;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.BuildContext;
@@ -33,15 +33,14 @@ import net.sf.json.JSONObject;
  * environment variables (like in a Job). This prevents issues e.g. when triggering
  * remote jobs in a parallel pipeline step.
  */
-@ParametersAreNullableByDefault
 public class Handle implements Serializable {
 
     private static final long serialVersionUID = 4418782245518194292L;
 
-    @Nonnull
+    @NonNull
     private final RemoteBuildConfiguration remoteBuildConfiguration;
 
-    @Nonnull
+    @NonNull
     private RemoteBuildInfo buildInfo;
 
     @Nullable
@@ -58,10 +57,10 @@ public class Handle implements Serializable {
     /**
      * The current local Item (Job, Pipeline,...) where this plugin is currently used.
      */
-    @Nonnull
+    @NonNull
     private final String currentItem;
 
-    @Nonnull
+    @NonNull
     private final RemoteJenkinsServer effectiveRemoteServer;
 
     /*
@@ -71,12 +70,12 @@ public class Handle implements Serializable {
      * already finished.
      * TODO: Once we found a way to log to the pipeline log directly we can switch
      */
-    @Nonnull
+    @NonNull
     private String lastLog;
 
 
-    public Handle(@Nonnull RemoteBuildConfiguration remoteBuildConfiguration, @Nonnull RemoteBuildInfo buildInfo, @Nonnull String currentItem,
-        @Nonnull RemoteJenkinsServer effectiveRemoteServer, @Nonnull JSONObject remoteJobMetadata)
+    public Handle(@NonNull RemoteBuildConfiguration remoteBuildConfiguration, @NonNull RemoteBuildInfo buildInfo, @NonNull String currentItem,
+        @NonNull RemoteJenkinsServer effectiveRemoteServer, @NonNull JSONObject remoteJobMetadata)
     {
         this.remoteBuildConfiguration = remoteBuildConfiguration;
         this.buildInfo = buildInfo;
@@ -183,7 +182,7 @@ public class Handle implements Serializable {
      *
      * @return the build number, or 0 if it could not be identified (yet).
      */
-    @Nonnull
+    @NonNull
     @Whitelisted
     public int getBuildNumber() {
         return buildInfo.getBuildNumber();
@@ -194,7 +193,7 @@ public class Handle implements Serializable {
      *
      * @return {@link org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob.RemoteBuildInfo} the build info
      */
-    @Nonnull
+    @NonNull
     @Whitelisted
     public RemoteBuildInfo getBuildInfo() {
         return buildInfo;
@@ -205,7 +204,7 @@ public class Handle implements Serializable {
      *
      * @return {@link org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob.RemoteBuildStatus} the build status
      */
-    @Nonnull
+    @NonNull
     @Whitelisted
     public RemoteBuildStatus getBuildStatus() {
         return buildInfo.getStatus();
@@ -223,7 +222,7 @@ public class Handle implements Serializable {
      * @throws InterruptedException
      *            if any thread has interrupted the current thread.
      */
-    @Nonnull
+    @NonNull
     @Whitelisted
     public RemoteBuildStatus updateBuildStatus() throws IOException, InterruptedException {
         return updateBuildStatus(false);
@@ -241,13 +240,13 @@ public class Handle implements Serializable {
      * @throws InterruptedException
      *            if any thread has interrupted the current thread.
      */
-    @Nonnull
+    @NonNull
     @Whitelisted
     public RemoteBuildStatus updateBuildStatusBlocking() throws IOException, InterruptedException {
         return updateBuildStatus(true);
     }
 
-    @Nonnull
+    @NonNull
     private RemoteBuildStatus updateBuildStatus(boolean blockUntilFinished) throws IOException, InterruptedException {
       //Return if buildStatus exists and is final (does not change anymore)
       if(buildInfo.isFinished()) return buildInfo.getStatus();
@@ -275,7 +274,7 @@ public class Handle implements Serializable {
      *
      * @return {@link hudson.model.Result} the build result
      */
-    @Nonnull
+    @NonNull
     @Whitelisted
     public Result getBuildResult() {
         return buildInfo.getResult();
@@ -288,7 +287,7 @@ public class Handle implements Serializable {
      *
      * @return The latest log entries from the last called method.
      */
-    @Nonnull
+    @NonNull
     @Whitelisted
     public String lastLog() {
         String log = lastLog.trim();

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/RemoteBuildPipelineStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/RemoteBuildPipelineStep.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.BasicBuildContext;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.BuildContext;
@@ -299,7 +299,7 @@ public class RemoteBuildPipelineStep extends Step {
 		}
 
 		@Restricted(NoExternalUse.class)
-		@Nonnull
+		@NonNull
 		public ListBoxModel doFillRemoteJenkinsNameItems() {
 			RemoteBuildConfiguration.DescriptorImpl descriptor = Descriptor.findByDescribableClassName(
 					ExtensionList.lookup(RemoteBuildConfiguration.DescriptorImpl.class),

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/remoteJob/QueueItem.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/remoteJob/QueueItem.java
@@ -3,7 +3,7 @@ package org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import hudson.AbortException;
 
@@ -16,14 +16,14 @@ public class QueueItem
 {
     final static private String key = "Location";
 
-    @Nonnull
+    @NonNull
     private final String location;
 
-    @Nonnull
+    @NonNull
     private final String id;
 
 
-    public QueueItem(@Nonnull Map<String,List<String>> header) throws AbortException
+    public QueueItem(@NonNull Map<String,List<String>> header) throws AbortException
     {
         if (!header.containsKey(key))
             throw new AbortException(String.format("Error triggering the remote job. The header of the response has an unexpected format: %n%s", header));
@@ -36,12 +36,12 @@ public class QueueItem
         }
     }
 
-    @Nonnull
+    @NonNull
     public String getLocation() {
         return location;
     }
 
-    @Nonnull
+    @NonNull
     public String getId() {
         return id;
     }

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/remoteJob/QueueItemData.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/remoteJob/QueueItemData.java
@@ -3,13 +3,13 @@ package org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.BuildContext;
-
 import net.sf.json.JSONException;
+
 import net.sf.json.JSONObject;
 
 /**
@@ -18,13 +18,13 @@ import net.sf.json.JSONObject;
  */
 public class QueueItemData
 {
-    @Nonnull
+    @NonNull
     private QueueItemStatus status;
 
     @Nullable
     private String why;
 
-    @Nonnull
+    @NonNull
     private int buildNumber;
 
     @Nullable
@@ -71,7 +71,7 @@ public class QueueItemData
         return status == QueueItemStatus.CANCELLED;
     }
 
-    @Nonnull
+    @NonNull
     public QueueItemStatus getStatus() {
         return status;
     }
@@ -81,7 +81,7 @@ public class QueueItemData
         return why;
     }
 
-    @Nonnull
+    @NonNull
     public int getBuildNumber()
     {
         return buildNumber;
@@ -103,7 +103,7 @@ public class QueueItemData
      * @throws MalformedURLException
      *            if there is an error creating the build URL.
      */
-    public void update(@Nonnull BuildContext context, @Nonnull JSONObject queueResponse) throws MalformedURLException
+    public void update(@NonNull BuildContext context, @NonNull JSONObject queueResponse) throws MalformedURLException
     {
         if (queueResponse.getBoolean("blocked")) status = QueueItemStatus.BLOCKED;
         if (queueResponse.getBoolean("buildable")) status = QueueItemStatus.BUILDABLE;
@@ -134,7 +134,7 @@ public class QueueItemData
         }
     }
 
-    private boolean getOptionalBoolean(@Nonnull JSONObject queueResponse, @Nonnull String attribute)
+    private boolean getOptionalBoolean(@NonNull JSONObject queueResponse, @NonNull String attribute)
     {
         if (queueResponse.containsKey(attribute))
             return queueResponse.getBoolean(attribute);

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/remoteJob/RemoteBuildInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/remoteJob/RemoteBuildInfo.java
@@ -3,9 +3,9 @@ package org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob;
 import java.io.Serializable;
 import java.net.URL;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import hudson.AbortException;
 import hudson.model.Result;
@@ -39,16 +39,16 @@ public class RemoteBuildInfo implements Serializable
     @CheckForNull
     private String queueId;
 
-    @Nonnull
+    @NonNull
     private int buildNumber;
 
     @CheckForNull
     private URL buildURL;
 
-    @Nonnull
+    @NonNull
     private RemoteBuildStatus status;
 
-    @Nonnull
+    @NonNull
     private Result result;
 
 
@@ -63,7 +63,7 @@ public class RemoteBuildInfo implements Serializable
         return queueId;
     }
 
-    @Nonnull
+    @NonNull
     public int getBuildNumber()
     {
         return buildNumber;
@@ -75,13 +75,13 @@ public class RemoteBuildInfo implements Serializable
         return buildURL;
     }
 
-    @Nonnull
+    @NonNull
     public RemoteBuildStatus getStatus()
     {
         return status;
     }
 
-    @Nonnull
+    @NonNull
     public Result getResult()
     {
         return result;
@@ -92,7 +92,7 @@ public class RemoteBuildInfo implements Serializable
         this.status = RemoteBuildStatus.QUEUED;
     }
 
-    public void setBuildData(@Nonnull int buildNumber, @Nullable URL buildURL) throws AbortException
+    public void setBuildData(@NonNull int buildNumber, @Nullable URL buildURL) throws AbortException
     {
         if (buildURL == null) {
             throw new AbortException(String.format("Unexpected remote build status: %s", toString()));
@@ -125,7 +125,7 @@ public class RemoteBuildInfo implements Serializable
         this.result = Result.fromString(result);
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public String toString()
     {

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/remoteJob/RemoteBuildInfoExporterAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/remoteJob/RemoteBuildInfoExporterAction.java
@@ -1,12 +1,12 @@
 package org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-
-import javax.annotation.Nonnull;
 
 import hudson.EnvVars;
 import hudson.model.AbstractBuild;
@@ -33,7 +33,7 @@ public class RemoteBuildInfoExporterAction implements EnvironmentContributingAct
         addBuildReferenceSafe(buildRef);
     }
 
-    public static RemoteBuildInfoExporterAction addBuildInfoExporterAction(@Nonnull Run<?, ?> parentBuild, String triggeredProjectName, int buildNumber, URL jobURL, RemoteBuildInfo buildInfo) {
+    public static RemoteBuildInfoExporterAction addBuildInfoExporterAction(@NonNull Run<?, ?> parentBuild, String triggeredProjectName, int buildNumber, URL jobURL, RemoteBuildInfo buildInfo) {
         BuildReference reference = new BuildReference(triggeredProjectName, buildNumber, jobURL, buildInfo);
 
         RemoteBuildInfoExporterAction action;

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/utils/Base64Utils.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/utils/Base64Utils.java
@@ -3,9 +3,9 @@ package org.jenkinsci.plugins.ParameterizedRemoteTrigger.utils;
 import static org.apache.commons.lang.StringUtils.isEmpty;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.UnsupportedEncodingException;
 
 import org.apache.commons.codec.binary.Base64;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.BuildContext;
@@ -41,7 +41,7 @@ public class Base64Utils
      *            if there is a failure while replacing token macros, or
      *            if there is a failure while encoding user:password.
      */
-    @Nonnull
+    @NonNull
     public static String generateAuthorizationHeaderValue(String authType, String user, String password,
                 BuildContext context, boolean applyMacro) throws IOException
     {
@@ -56,7 +56,7 @@ public class Base64Utils
         return authTypeKey + " " + encodedTuple;
     }
 
-    @Nonnull
+    @NonNull
     private static String getAuthType(String authType)
     {
         if ("Basic".equalsIgnoreCase(authType)) return "Basic";

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/utils/HttpHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/utils/HttpHelper.java
@@ -13,7 +13,6 @@ import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;
 import net.sf.json.util.JSONUtils;
 
-import javax.annotation.Nonnull;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.KeyManager;
@@ -204,7 +203,7 @@ public class HttpHelper {
 	 * @throws IOException
 	 *             if the request failed.
 	 */
-	@Nonnull
+	@NonNull
 	private static JenkinsCrumb getCrumb(BuildContext context, Auth2 overrideAuth, boolean isCacheEnabled)
 			throws IOException {
 		String address = context.effectiveRemoteServer.getAddress();


### PR DESCRIPTION
## Replace JSR-305 annotations with spotbugs annotations

Annotations for Nonnull, CheckForNull, and several others were proposed for Java as part of dormant Java specification request JSR-305. The proposal never became a part of standard Java.

Jenkins plugins should switch from using JSR-305 annotations to use Spotbugs annotations that provide the same semantics.

The [mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/uE1wwtVi1W0/m/gLxdEJmlBQAJ) from James Nord describes the affected annotations and why they should be replaced with annotations that are actively maintained.

The ["Improve a plugin" tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/) provides instructions to perform this change.

An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/jenkins/javaxannotationstospotbugs) is also available and is even better than the tutorial.

### Testing done

Confirmed that automated tests pass on Linux with Java 21.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
