### PR TITLE
[JENKINS-73142] Adapt Parameterized Remote Trigger for Jetty 12 (EE 8)

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/remoteJob/QueueItemTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/remoteJob/QueueItemTest.java
@@ -1,13 +1,13 @@
 package org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob;
 
 import hudson.AbortException;
-import org.eclipse.jetty.server.Response;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.ConnectionResponse;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import java.net.HttpURLConnection;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -66,7 +66,7 @@ public class QueueItemTest {
     @Test
     public void test() {
         // ConnectionResponse creates case-insensitive map of header
-        ConnectionResponse connectionResponse = new ConnectionResponse(header, Response.SC_OK);
+        ConnectionResponse connectionResponse = new ConnectionResponse(header, HttpURLConnection.HTTP_OK);
 
         try {
             QueueItem queueItem = new QueueItem(connectionResponse.getHeader());


### PR DESCRIPTION
### Description
The goal was to adapt the changes of Jetty 12 EE 8 for `parameterized-remote-trigger-plugin` see https://issues.jenkins.io/browse/JENKINS-73142.

### Problem
Post adaption of `Jetty12EE8`, `org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob.QueueItemTest` was failing at compile time.

### Analysis
In Jetty10, `org.eclipse.jetty.server.Response` inherits the http status codes (SC_Ok etc) from `javax.servlet.http.HttpServletResponse`  whereas in Jetty12 its not.

### Solution
Used the status code 200 from `java.net.HttpURLConnection.HTTP_OK` rather than jetty. 

### Testing
Tested locally & build passed. 

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
