### PR TITLE
Fix Jenkinsfile comments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,7 @@
-// Builds a module using https://github.com/jenkins-infra/pipeline-library
-// Requirements:
-//   - agents with label 'linux' and 'windows'
-//   - tools with label 'jdk8' and 'mvn'
-//   - latest Pipeline plugins, 'Timestamper' plugin
-//   - recommended to use this Jenkinsfile with 'Multibranch Pipeline' plugin
-
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
 buildPlugin(useContainerAgent: true, configurations: [
   [platform: 'linux', jdk: 21],
   [platform: 'windows', jdk: 17],


### PR DESCRIPTION
## Fix Jenkinsfile comments

Remove the jdk8 reference, since the plugin no longer supports JDK 8.

Provide link to Pipeline library documentation for details.

### Testing done

None.  Rely on ci.jenkins.io to confirm it works as expected.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
