### PR TITLE
JENKINS-75957: Correct bearer token header

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/BearerTokenAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/BearerTokenAuth.java
@@ -38,7 +38,7 @@ public class BearerTokenAuth extends Auth2 {
 
     @Override
     public void setAuthorizationHeader(URLConnection connection, BuildContext context) throws IOException {
-        connection.setRequestProperty("Authorization", "Bearer: " + getToken().getPlainText());
+        connection.setRequestProperty("Authorization", "Bearer " + getToken().getPlainText());
     }
 
     @Override


### PR DESCRIPTION
Correct the bearer token header passed in the Parameterized Remote Trigger plugin.

The header when using bearer token authorization is incorrect because it contained an unnecessary colon `:`.

See issue https://issues.jenkins.io/browse/JENKINS-75957

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes

