### PR TITLE
No need to request a crumb when using API token authn

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/Auth2.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/Auth2.java
@@ -42,6 +42,13 @@ public abstract class Auth2 extends AbstractDescribableImpl<Auth2> implements Se
      */
     public abstract void setAuthorizationHeader(URLConnection connection, BuildContext context) throws IOException;
 
+    /**
+     * Whether a Jenkins crumb is required on {@code POST} requests.
+     */
+    public boolean requiresCrumb() {
+        return true;
+    }
+
     public abstract String toString();
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/TokenAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/TokenAuth.java
@@ -56,6 +56,11 @@ public class TokenAuth extends Auth2 {
     }
 
     @Override
+    public boolean requiresCrumb() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "'" + getDescriptor().getDisplayName() + "' as user '" + getUserName() + "'";
     }


### PR DESCRIPTION
While trying to track down a 400 error from the downstream server, I noticed that the error was coming from `HttpHelper.getCrumb`, which made no sense since I was using an API token to authenticate and Jenkins has waived the requirement for a CSRF crumb on `POST` requests when using API tokens for years now.