### PR TITLE
Warn about URLs ending with slash

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
@@ -210,6 +210,10 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
                 return FormValidation.warning("The remote address can not be empty, or it must be overridden on the job configuration.");
             }
 
+            if (address.endsWith("/")) {
+                return FormValidation.warning("The remote address is not expected to end with a slash (/).");
+            }
+
             // check if we have a valid, well-formed URL
             try {
                 host = new URL(address);

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/utils/FormValidationUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/utils/FormValidationUtils.java
@@ -53,6 +53,7 @@ public class FormValidationUtils
         final String TEXT_WARNING_JOB_VARIABLE = "You are using a variable in the 'Remote Job Name or URL' ('job') field. You have to make sure the value at runtime results in the full job URL";
         final String TEXT_ERROR_NO_URL_AT_ALL = "You have to configure either 'Select a remote host' ('remoteJenkinsName'), 'Override remote host URL' ('remoteJenkinsUrl') or specify a full job URL 'Remote Job Name or URL' ('job')";
 
+        // TODO warn about URLs ending with slash
         if(isEmpty(jobNameOrUrl)) {
             return new RemoteURLCombinationsResult(
                         FormValidation.error("'Remote Job Name or URL' ('job') not specified"),


### PR DESCRIPTION
As noted in #97, URLs ending in `/` do not seem to be supported. Documentation screenshots consistently show URLs without, so just treat that as required. I had a hard time following all the places where URLs are constructed, so adjusting all of them to tolerate URLs with or without a trailing slash seemed tricky.